### PR TITLE
[RFC] PSA/ebpf backed: update psabpf-ctl to the latest version

### DIFF
--- a/backends/ebpf/psa/README.md
+++ b/backends/ebpf/psa/README.md
@@ -277,9 +277,6 @@ member reference to be returned. Next, the eBPF programs uses the obtained membe
 map to retrieve the action specification. Hence, the eBPF program does one additional lookup to the additional BPF map,
 if the ActionProfile is specified for a P4 table.
 
-**Note:** As of April 2022, support for ActionProfile extern in `psabpf-ctl` CLI/API is not implemented yet. As a workaround
-you can use `psabpf-ctl table` command for this extern.
-
 ### ActionSelector
 
 [ActionSelector](https://p4.org/p4-spec/docs/PSA-v1.1.0.html#sec-action-selector) is a table implementation similar to
@@ -386,8 +383,7 @@ $ psabpf-ctl meter update pipe "$PIPELINE" DemoIngress_meter index 0 132000:1000
 
 #### Direct Meter
 [Direct Meter](https://p4.org/p4-spec/docs/PSA.html#sec-direct-meters) is always associated with the table entry that matched. 
-The Direct Meter state is stored within the table entry value.  
-**Note:** For now we don't support Direct Meters in `psabpf-ctl` tool, but we will add it soon.
+The Direct Meter state is stored within the table entry value.
 
 ### value_set
 
@@ -395,9 +391,6 @@ The Direct Meter state is stored within the table entry value.
 parser state based on runtime values. The P4-eBPF compiler generates additional hash map for each `ValueSet` instance. In
 select case expression each `select()` on `ValueSet` is translated into a lookup into the BPF hash map to check if an entry
 for a given key exists. A value of the BPF map is ignored.
-
-**Note:** As of April 2022, support for value_set in `psabpf-ctl` CLI/API is not implemented yet. As a workaround you can
-use the `bpftool` command.
 
 ### Random 
 

--- a/backends/ebpf/tests/ptf/table_implementation.py
+++ b/backends/ebpf/tests/ptf/table_implementation.py
@@ -41,9 +41,8 @@ class SimpleActionProfilePSATest(P4EbpfTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet_any_port(self, pkt, ALL_PORTS)
 
-        # FIXME: API/CLI for ActionProfile is not done yet, we are using table API/CLI for now
-        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
-        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[0x10])
+        ref = self.action_profile_add_action(ap="MyIC_ap", action=2, data=[0x1122])
+        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[ref])
 
         testutils.send_packet(self, PORT0, pkt)
         pkt[Ether].type = 0x1122
@@ -57,9 +56,9 @@ class ActionProfileTwoTablesSameInstancePSATest(P4EbpfTest):
     p4_file_path = "p4testdata/action-profile2.p4"
 
     def runTest(self):
-        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
-        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[0x10])
-        self.table_add(table="MyIC_tbl2", key=["AA:BB:CC:DD:EE:FF"], references=[0x10])
+        ref = self.action_profile_add_action(ap="MyIC_ap", action=2, data=[0x1122])
+        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[ref])
+        self.table_add(table="MyIC_tbl2", key=["AA:BB:CC:DD:EE:FF"], references=[ref])
 
         pkt = testutils.simple_ip_packet(eth_src="11:22:33:44:55:66", eth_dst="22:33:44:55:66:77")
         testutils.send_packet(self, PORT0, pkt)
@@ -80,8 +79,8 @@ class ActionProfileLPMTablePSATest(P4EbpfTest):
 
     def runTest(self):
         # Match all 11:22:33:44:55:xx MAC addresses
-        self.table_add(table="MyIC_tbl", key=["0x112233445500/40"], references=[0x10])
-        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
+        ref = self.action_profile_add_action(ap="MyIC_ap", action=2, data=[0x1122])
+        self.table_add(table="MyIC_tbl", key=["0x112233445500/40"], references=[ref])
 
         pkt = testutils.simple_ip_packet(eth_src="AA:BB:CC:DD:EE:FF", eth_dst="22:33:44:55:66:77")
         testutils.send_packet(self, PORT0, pkt)
@@ -103,10 +102,10 @@ class ActionProfileActionRunPSATest(P4EbpfTest):
     p4_file_path = "p4testdata/action-profile-action-run.p4"
 
     def runTest(self):
-        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
-        self.table_add(table="MyIC_ap", key=[0x20], action=1, data=["AA:BB:CC:DD:EE:FF"])
-        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[0x10])
-        self.table_add(table="MyIC_tbl", key=["AA:BB:CC:DD:EE:FF"], references=[0x20])
+        ref1 = self.action_profile_add_action(ap="MyIC_ap", action=2, data=[0x1122])
+        ref2 = self.action_profile_add_action(ap="MyIC_ap", action=1, data=["AA:BB:CC:DD:EE:FF"])
+        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[ref1])
+        self.table_add(table="MyIC_tbl", key=["AA:BB:CC:DD:EE:FF"], references=[ref2])
 
         # action MyIC_a1
         pkt = testutils.simple_ip_packet(eth_src="AA:BB:CC:DD:EE:FF", eth_dst="22:33:44:55:66:77")
@@ -132,8 +131,8 @@ class ActionProfileHitPSATest(P4EbpfTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_no_other_packets(self)
 
-        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
-        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[0x10])
+        ref = self.action_profile_add_action(ap="MyIC_ap", action=2, data=[0x1122])
+        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[ref])
 
         testutils.send_packet(self, PORT0, pkt)
         pkt[Ether].type = 0x1122

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -428,7 +428,7 @@ class ParserValueSetPSATest(P4EbpfTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_no_other_packets(self)
 
-        self.update_map("IngressParserImpl_pvs", '1 0 0 10', '0 0 0 0')
+        self.value_set_insert(name="IngressParserImpl_pvs", value=["10.0.0.1"])
 
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet_any_port(self, pkt, ALL_PORTS)
@@ -547,9 +547,9 @@ class PSATernaryTest(P4EbpfTest):
 
         # flow rules 'tbl_ternary_4':
         # 2. hdr.ethernet.srcAddr=00:00:33:44:55:00^00:00:FF:FF:FF:00 => action 1 priority 10
-        self.table_add(table="ingress_ap", key=[0x10], action=1, data=[])
+        ref3 = self.action_profile_add_action(ap="ingress_ap", action=1, data=[])
         self.table_add(table="ingress_tbl_ternary_4", key=["00:00:33:44:55:00^00:00:FF:FF:FF:00"],
-                       references=["0x10"], priority=10)
+                       references=[ref3], priority=10)
 
         pkt = testutils.simple_udp_packet(eth_src="11:22:33:44:55:66", ip_src='1.2.3.4', ip_dst='192.168.2.1')
         testutils.send_packet(self, PORT0, pkt)

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -82,7 +82,7 @@ function install_ptf_ebpf_test_deps() (
   git clone --recursive https://github.com/P4-Research/psabpf.git /tmp/psabpf
   cd /tmp/psabpf
   # FIXME: psabpf is under heavy development, later use git tags when it will be ready to use
-  git reset --hard 7a4a8be
+  git reset --hard edacd0d
   ./build_libbpf.sh
   mkdir build
   cd build


### PR DESCRIPTION
Changes in `psabpf` from previous version:
- Member/group reference is printed using JSON, not by a pure number on `stdout`.
- Added support for `ActionProfile` and `value_set`.

At this point, `psabpf-ctl` is used to handle all the externs in PTF tests and no maps are written directly. `bpftool` is still used for reading maps but only for validation purposes where `psabpf-ctl` hides internal state of of the extern.