### PR TITLE
[RFC] Implement caching for ActionSelector, LPM and ternary tables

### DIFF
--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -355,6 +355,11 @@ void ControlBodyTranslator::processApply(const P4::ApplyMethod* method) {
     builder->endOfStatement(true);
     builder->blockEnd(true);
 
+    if (table->cacheEnabled()) {
+        table->emitCacheUpdate(builder, keyname, valueName);
+        builder->blockEnd(true);
+    }
+
     builder->emitIndent();
     builder->appendFormat("if (%s != NULL) ", valueName.c_str());
     builder->blockStart();

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -84,4 +84,10 @@ EbpfOptions::EbpfOptions() {
         },
         "[psa only] Select the mode used to pass metadata from XDP to TC "
         "(possible values: meta, head, cpumap).");
+    registerOption("--table-caching", nullptr,
+        [this](const char *) {
+            enableTableCache = true;
+            return true;
+        },
+        "[psa only] Enable caching entries for tables with lpm or ternary key");
 }

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -84,8 +84,9 @@ EbpfOptions::EbpfOptions() {
         },
         "[psa only] Select the mode used to pass metadata from XDP to TC "
         "(possible values: meta, head, cpumap).");
-    registerOption("--table-caching", nullptr,
-        [this](const char *) {
+    registerOption(
+        "--table-caching", nullptr,
+        [this](const char*) {
             enableTableCache = true;
             return true;
         },

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -37,6 +37,8 @@ class EbpfOptions : public CompilerOptions {
     enum XDP2TC xdp2tcMode = XDP2TC_NONE;
     // maximum number of unique ternary masks
     unsigned int maxTernaryMasks = 128;
+    // Enable table cache for LPM and ternary tables
+    bool enableTableCache = false;
 
     EbpfOptions();
 

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -739,8 +739,7 @@ void EBPFTable::emitInitializer(CodeBuilder* builder) {
 }
 
 void EBPFTable::emitLookup(CodeBuilder* builder, cstring key, cstring value) {
-    if (cacheEnabled())
-        emitCacheLookup(builder, key, value);
+    if (cacheEnabled()) emitCacheLookup(builder, key, value);
 
     if (!isTernaryTable()) {
         builder->target->emitTableLookup(builder, dataMapName, key, value);

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -739,6 +739,9 @@ void EBPFTable::emitInitializer(CodeBuilder* builder) {
 }
 
 void EBPFTable::emitLookup(CodeBuilder* builder, cstring key, cstring value) {
+    if (cacheEnabled())
+        emitCacheLookup(builder, key, value);
+
     if (!isTernaryTable()) {
         builder->target->emitTableLookup(builder, dataMapName, key, value);
         builder->endOfStatement(true);

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -132,10 +132,14 @@ class EBPFTable : public EBPFTableBase {
 
     virtual bool cacheEnabled() { return false; }
     virtual void emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) {
-        (void) builder; (void) key; (void) value;
+        (void)builder;
+        (void)key;
+        (void)value;
     }
     virtual void emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) {
-        (void) builder; (void) key; (void) value;
+        (void)builder;
+        (void)key;
+        (void)value;
     }
 };
 

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -129,6 +129,14 @@ class EBPFTable : public EBPFTableBase {
     // Whether to drop packet if no match entry found.
     // Some table implementations may want to continue processing.
     virtual bool dropOnNoMatchingEntryFound() const { return true; }
+
+    virtual bool cacheEnabled() { return false; }
+    virtual void emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) {
+        (void) builder; (void) key; (void) value;
+    }
+    virtual void emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) {
+        (void) builder; (void) key; (void) value;
+    }
 };
 
 class EBPFCounterTable : public EBPFTableBase {

--- a/backends/ebpf/psa/README.md
+++ b/backends/ebpf/psa/README.md
@@ -541,7 +541,10 @@ Refer to [the bpftool guide](https://manpages.ubuntu.com/manpages/focal/man8/bpf
 In case when lookup into map is expensive (when table has `lpm` or `ternary` key) value for given key might be cached
 in fast exact-match map. For this purpose `BPF_MAP_TYPE_LRU_HASH` map type is used, which shares its implementation
 with hash map (`BPF_MAP_TYPE_HASH`). LRU map has good read performance and lower performance on map update due to
-maintenance process.
+maintenance process. In other words, this optimization fits into case where value of table key changes infrequently
+between packets.
+
+To enable "Table caching" pass option `--table-caching` to the compiler.
 
 By default, lookup into map is done in the following way:
 ```c
@@ -588,7 +591,57 @@ if (cached_value != NULL) {
 }
 ```
 
-To enable "Table caching" pass option `--table-caching` to the compiler.
+Note that cached table entries are a copy of an original entry. This causes that extern which preserve internal state inside
+table entry (like `DirectMeter` or `DirectCounter`) can't be used with cache due to two existing different states. Compiler
+will not enable table caching for tables containing such direct extern.
+
+When updating table with enabled cache, the cache must be invalidated in order to update to be effective. The simplest way
+to do this is to remove all entries from LRU map, which is done automatically by the NIKSS library.
+
+Similar approach to this is done in `Action Selector` extern when group reference is present. Lookup with cache into
+`Action Selctor` looks like below where cache is used to skip checksum calculation and member selection if possible:
+```c
+struct ingress_as_value * as_value = NULL;  // pointer to an action data
+u32 as_action_ref = value->ingress_as_ref;  // value->ingress_as_ref is entry from table (reference)
+u8 as_group_state = 0;                      // from which map read action data
+struct ingress_as_key_cache key_cache = {0};
+u8 do_update_cache = 0;
+if (value->ingress_as_is_group_ref != 0) {
+    key_cache.group_ref = value->ingress_as_ref; // group reference
+    key_cache.field0 = /* fill selectors value */;
+    as_value = BPF_MAP_LOOKUP_ELEM(ingress_as_cache, &key_cache);
+    if (as_value != NULL) {
+        as_group_state = 2; // cache hit, forbid later lookups into maps
+    } else {
+        do_update_cache = 1; // cache miss, update cache later, below normal lookup
+        void * as_group_map = BPF_MAP_LOOKUP_ELEM(ingress_as_groups, &as_action_ref);  // get group map
+        if (as_group_map != NULL) {
+            u32 * num_of_members = bpf_map_lookup_elem(as_group_map, &ebpf_zero);
+            if (num_of_members != NULL) {
+                if (*num_of_members != 0) {
+                    /* calculate checksum here */
+                    u64 as_checksum_val = /* calculated checksum */;
+                    as_action_ref = /* determine member reference based on checksum */;
+                } else {
+                    as_group_state = 1; // execute default action when group is empty
+                }
+            } else {
+                return TC_ACT_SHOT; // number of members not found
+            }
+        } else {
+            return TC_ACT_SHOT; // group not found
+        }
+    }
+}
+if (as_group_state == 0) {
+    as_value = BPF_MAP_LOOKUP_ELEM(ingress_as_actions, &as_action_ref); // member action data (valid member reference)
+} else if (as_group_state == 1) {
+    as_value = BPF_MAP_LOOKUP_ELEM(ingress_as_defaultActionGroup, &ebpf_zero);  // default group action data
+}
+if (as_value != NULL && do_update_cache != 0) {
+    BPF_MAP_UPDATE_ELEM(ingress_as_cache, &key_cache, as_value, BPF_ANY); // update cache
+}
+```
 
 # TODO / Limitations
 

--- a/backends/ebpf/psa/README.md
+++ b/backends/ebpf/psa/README.md
@@ -535,6 +535,61 @@ $ bpftool help
 
 Refer to [the bpftool guide](https://manpages.ubuntu.com/manpages/focal/man8/bpftool-prog.8.html) for more examples how to use it.
 
+# Implemented optimizations
+
+## Table caching
+In case when lookup into map is expensive (when table has `lpm` or `ternary` key) value for given key might be cached
+in fast exact-match map. For this purpose `BPF_MAP_TYPE_LRU_HASH` map type is used, which shares its implementation
+with hash map (`BPF_MAP_TYPE_HASH`). LRU map has good read performance and lower performance on map update due to
+maintenance process.
+
+By default, lookup into map is done in the following way:
+```c
+struct table_key_type key = {};
+/* here fill key's fields */
+struct table_value_type *value = NULL;
+value = BPF_MAP_LOOKUP_ELEM(table_map, &key);
+if (value == NULL) {
+    /* miss; find default action */
+    hit = 0;
+    value = BPF_MAP_LOOKUP_ELEM(table_map_defaultAction, &ebpf_zero);
+} else {
+    hit = 1;
+}
+```
+With caching enabled, lookup into map will be done in little modified way:
+```c
+struct table_key_type key = {};
+/* here fill key's fields */
+struct table_value_type *value = NULL;
+struct table_value_type_cache *cached_value = NULL;
+cached_value = BPF_MAP_LOOKUP_ELEM(table_map_cache, &key);
+if (cached_value != NULL) {
+    /* cache hit */
+    value = &(cached_value->value);
+    hit = cached_value->hit;
+} else {
+    /* cache miss, normal lookup into map */
+    value = BPF_MAP_LOOKUP_ELEM(table_map, &key);
+    if (value == NULL) {
+        /* miss; find default action */
+        hit = 0;
+        value = BPF_MAP_LOOKUP_ELEM(table_map_defaultAction, &ebpf_zero);
+    } else {
+        hit = 1;
+    }
+    if (value != NULL) {
+        /* update cache if value has been found */
+        struct table_value_type_cache cache_update = { 0 };
+        cache_update.hit = hit;
+        __builtin_memcpy((void *) &(cache_update->value), (void *) value, sizeof(struct table_value_type));
+        BPF_MAP_UPDATE_ELEM(table_map_cache, &key, &cache_update, BPF_ANY);
+    }
+}
+```
+
+To enable "Table caching" pass option `--table-caching` to the compiler.
+
 # TODO / Limitations
 
 We list the known bugs/limitations below. Refer to the Roadmap section for features planned in the near future.

--- a/backends/ebpf/psa/README.md
+++ b/backends/ebpf/psa/README.md
@@ -544,9 +544,14 @@ Table caching optimizes P4 table lookups by adding a cache with all `exact` matc
 - table with `lpm` (and/or exact) key - skip slow `LPM_TRIE` map (especially when there is many entries) if the key was matched earlier.
 - `ActionSelector` member selection from group - skip slow checksum calculation for `selector` key if it was calculated earlier.
 
-The fast exact-match map is added in front of each instance of a table that contains a `lpm`, `ternary` or `selector` match key. The table cache is implemented with `BPF_MAP_TYPE_LRU_HASH`, which shares its implementation with the BPF hash map. The LRU map provides a good lookup performance, but lower performance on map updates due to a maintenance process. Thus, this optimization fits into use cases, where a value of table key changes infrequently between packets.
+The fast exact-match map is added in front of each instance of a table that contains a `lpm`, `ternary` or `selector` match
+key. The table cache is implemented with `BPF_MAP_TYPE_LRU_HASH`, which shares its implementation with the BPF hash map.
+The LRU map provides a good lookup performance, but lower performance on map updates due to a maintenance process. Thus,
+this optimization fits into use cases, where a value of table key changes infrequently between packets.
 
-This optimization may not improve performance in every case, so it must be explicitly enabled by compiler option. To enable table caching pass `--table-caching` to the compiler. 
+This optimization may not improve performance in every case, so it must be explicitly enabled by compiler option. To enable
+table caching pass `--table-caching` to the compiler.
+
 # TODO / Limitations
 
 We list the known bugs/limitations below. Refer to the Roadmap section for features planned in the near future.
@@ -557,7 +562,7 @@ with some NICs. So far, we have verified the correct behavior with Intel 82599ES
 - `lookahead()` with bit fields (e.g., `bit<16>`) doesn't work.
 - `@atomic` operation is not supported yet.
 - `psa_idle_timeout` is not supported yet.
-- DirectCounter and DirectMeter externs are not supported for P4 tables with implementation (ActionProfile).
+- DirectCounter and DirectMeter externs are not supported for P4 tables with implementation (ActionProfile or ActionSelector).
 - The `xdp2tc=head` mode works only for packets larger than 34 bytes (the size of Ethernet and IPv4 header).
 - `value_set` only supports the exact match type and can only match on a single field in the `select()` expression.
 - The number of entries in ternary tables are limited by the number of unique ternary masks. If a P4 program uses many ternary tables and the `--max-ternary-masks` (default: 128) is set 
@@ -565,6 +570,12 @@ with some NICs. So far, we have verified the correct behavior with Intel 82599ES
   requires iteration over BPF maps. Note that the recent kernel introduced the [bpf_for_each_map_elem()](https://lwn.net/Articles/846504/) helper that should simplify the iteration process and help to overcome the current limitation.
 - Setting a size of ternary tables does not currently work. 
 - DirectMeter cannot be used if a table defines `ternary` match fields, as [BPF spinlocks are not allowed in inner maps of map-in-map](https://patchwork.ozlabs.org/project/netdev/patch/20190124041403.2100609-2-ast@kernel.org/).
+- Table cache optimization can't be enabled on tables with DirectCounter or DirectMeter due to two different states of a
+  table entry. Tables with these externs will not have enabled cache optimization even when enabled by compiler option.
+- When table cache optimization is enabled for a table, the number of cached entries is determined as a half of table size.
+  This would be more configurable or smart during compilation.
+- Updates to tables or ActionSelector with enabled table cache optimization require cache invalidation. `nikss` library
+  will remove all cached entries if it detects cache.
 
 # Roadmap
 

--- a/backends/ebpf/psa/ebpfPsaTable.cpp
+++ b/backends/ebpf/psa/ebpfPsaTable.cpp
@@ -916,8 +916,19 @@ void EBPFTablePSA::tryEnableTableCache() {
     }
 
     tableCacheEnabled = true;
-    cacheValueTypeName = valueTypeName + "_cache";
+    createCacheTypeNames(false, true);
+}
+
+void EBPFTablePSA::createCacheTypeNames(bool isCacheKeyType, bool isCacheValueType) {
     cacheTableName = instanceName + "_cache";
+
+    cacheKeyTypeName = keyTypeName;
+    if (isCacheKeyType)
+        cacheKeyTypeName = keyTypeName + "_cache";
+
+    cacheValueTypeName = valueTypeName;
+    if (isCacheValueType)
+        cacheValueTypeName = valueTypeName + "_cache";
 }
 
 void EBPFTablePSA::emitCacheTypes(CodeBuilder* builder) {
@@ -950,7 +961,7 @@ void EBPFTablePSA::emitCacheInstance(CodeBuilder* builder) {
     // TODO: make cache size calculation more smart. Consider using annotation or compiler option.
     size_t cacheSize = std::max((size_t) 1, size / 2);
     builder->target->emitTableDecl(builder, cacheTableName, TableHashLRU,
-                                   "struct " + keyTypeName, "struct " + cacheValueTypeName,
+                                   "struct " + cacheKeyTypeName, "struct " + cacheValueTypeName,
                                    cacheSize);
 }
 

--- a/backends/ebpf/psa/ebpfPsaTable.cpp
+++ b/backends/ebpf/psa/ebpfPsaTable.cpp
@@ -225,6 +225,8 @@ EBPFTablePSA::EBPFTablePSA(const EBPFProgram* program, const IR::TableBlock* tab
     initDirectCounters();
     initDirectMeters();
     initImplementation();
+
+    tryEnableTableCache();
 }
 
 EBPFTablePSA::EBPFTablePSA(const EBPFProgram* program, CodeGenInspector* codeGen, cstring name)
@@ -320,11 +322,13 @@ void EBPFTablePSA::emitInstance(CodeBuilder* builder) {
                                        program->arrayIndexType, cstring("struct ") + valueTypeName,
                                        1);
     }
+
+    emitCacheInstance(builder);
 }
 
 void EBPFTablePSA::emitTypes(CodeBuilder* builder) {
     EBPFTable::emitTypes(builder);
-    // TODO: placeholder for handling PSA-specific types
+    emitCacheTypes(builder);
 }
 
 /**
@@ -897,6 +901,129 @@ cstring EBPFTablePSA::addPrefixFunc(bool trace) {
     }
 
     return addPrefixFunc;
+}
+
+void EBPFTablePSA::tryEnableTableCache() {
+    if (!program->options.enableTableCache)
+        return;
+    if (!isLPMTable() && !isTernaryTable())
+        return;
+    if (!counters.empty() || !meters.empty()) {
+        ::warning(ErrorType::WARN_UNSUPPORTED,
+                  "%1%: table cache can't be enabled due to direct extern(s)",
+                  table->container->name);
+        return;
+    }
+
+    tableCacheEnabled = true;
+    cacheValueTypeName = valueTypeName + "_cache";
+    cacheTableName = instanceName + "_cache";
+}
+
+void EBPFTablePSA::emitCacheTypes(CodeBuilder* builder) {
+    if (!tableCacheEnabled)
+        return;
+
+    builder->emitIndent();
+    builder->appendFormat("struct %s ", cacheValueTypeName.c_str());
+    builder->blockStart();
+
+    builder->emitIndent();
+    builder->appendFormat("struct %s value", valueTypeName.c_str());
+    builder->endOfStatement(true);
+
+    // additional metadata fields add at the end of this structure. This allows
+    // to simpler conversion cache value to value used by table
+
+    builder->emitIndent();
+    builder->append("u8 hit");
+    builder->endOfStatement(true);
+
+    builder->blockEnd(false);
+    builder->endOfStatement(true);
+}
+
+void EBPFTablePSA::emitCacheInstance(CodeBuilder* builder) {
+    if (!tableCacheEnabled)
+        return;
+
+    // TODO: make cache size calculation more smart. Consider using annotation or compiler option.
+    size_t cacheSize = std::max((size_t) 1, size / 2);
+    builder->target->emitTableDecl(builder, cacheTableName, TableHashLRU,
+                                   "struct " + keyTypeName, "struct " + cacheValueTypeName,
+                                   cacheSize);
+}
+
+void EBPFTablePSA::emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) {
+    cstring cacheVal = "cached_value";
+
+    builder->appendFormat("struct %s* %s = NULL", cacheValueTypeName.c_str(), cacheVal.c_str());
+    builder->endOfStatement(true);
+
+    builder->target->emitTraceMessage(builder, "Control: trying table cache...");
+
+    builder->emitIndent();
+    builder->target->emitTableLookup(builder, cacheTableName, key, cacheVal);
+    builder->endOfStatement(true);
+
+    builder->emitIndent();
+    builder->appendFormat("if (%s != NULL) ", cacheVal.c_str());
+    builder->blockStart();
+
+    builder->target->emitTraceMessage(builder,
+                                      "Control: table cache hit, skipping later lookup(s)");
+    builder->emitIndent();
+    builder->appendFormat("%s = &(%s->value)", value.c_str(), cacheVal.c_str());
+    builder->endOfStatement(true);
+    builder->emitIndent();
+    builder->appendFormat("%s = %s->hit",
+                          program->control->hitVariable.c_str(), cacheVal.c_str());
+    builder->endOfStatement(true);
+
+    builder->blockEnd(false);
+    builder->append(" else ");
+    builder->blockStart();
+
+    builder->target->emitTraceMessage(builder, "Control: table cache miss, nevermind");
+    builder->emitIndent();
+
+    // Do not end block here because we need lookup for (default) value
+    // and set hit variable at this indent level which is done in the control block
+}
+
+void EBPFTablePSA::emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) {
+    cstring cacheUpdateVarName = "cache_update";
+
+    builder->emitIndent();
+    builder->appendFormat("if (%s != NULL) ", value.c_str());
+    builder->blockStart();
+
+    builder->emitIndent();
+    builder->appendLine("/* update table cache */");
+
+    builder->emitIndent();
+    builder->appendFormat("struct %s %s = {0}",
+                          cacheValueTypeName.c_str(), cacheUpdateVarName.c_str());
+    builder->endOfStatement(true);
+
+    builder->emitIndent();
+    builder->appendFormat("%s.hit = %s",
+                          cacheUpdateVarName.c_str(), program->control->hitVariable.c_str());
+    builder->endOfStatement(true);
+
+    builder->emitIndent();
+    builder->appendFormat(
+            "__builtin_memcpy((void *) &(%s.value), (void *) %s, sizeof(struct %s))",
+            cacheUpdateVarName.c_str(), value.c_str(), valueTypeName.c_str());
+    builder->endOfStatement(true);
+
+    builder->emitIndent();
+    builder->target->emitTableUpdate(builder, cacheTableName, key, cacheUpdateVarName);
+    builder->newline();
+
+    builder->target->emitTraceMessage(builder, "Control: table cache updated");
+
+    builder->blockEnd(true);
 }
 
 }  // namespace EBPF

--- a/backends/ebpf/psa/ebpfPsaTable.cpp
+++ b/backends/ebpf/psa/ebpfPsaTable.cpp
@@ -904,10 +904,8 @@ cstring EBPFTablePSA::addPrefixFunc(bool trace) {
 }
 
 void EBPFTablePSA::tryEnableTableCache() {
-    if (!program->options.enableTableCache)
-        return;
-    if (!isLPMTable() && !isTernaryTable())
-        return;
+    if (!program->options.enableTableCache) return;
+    if (!isLPMTable() && !isTernaryTable()) return;
     if (!counters.empty() || !meters.empty()) {
         ::warning(ErrorType::WARN_UNSUPPORTED,
                   "%1%: table cache can't be enabled due to direct extern(s)",
@@ -923,17 +921,14 @@ void EBPFTablePSA::createCacheTypeNames(bool isCacheKeyType, bool isCacheValueTy
     cacheTableName = instanceName + "_cache";
 
     cacheKeyTypeName = keyTypeName;
-    if (isCacheKeyType)
-        cacheKeyTypeName = keyTypeName + "_cache";
+    if (isCacheKeyType) cacheKeyTypeName = keyTypeName + "_cache";
 
     cacheValueTypeName = valueTypeName;
-    if (isCacheValueType)
-        cacheValueTypeName = valueTypeName + "_cache";
+    if (isCacheValueType) cacheValueTypeName = valueTypeName + "_cache";
 }
 
 void EBPFTablePSA::emitCacheTypes(CodeBuilder* builder) {
-    if (!tableCacheEnabled)
-        return;
+    if (!tableCacheEnabled) return;
 
     builder->emitIndent();
     builder->appendFormat("struct %s ", cacheValueTypeName.c_str());
@@ -955,11 +950,10 @@ void EBPFTablePSA::emitCacheTypes(CodeBuilder* builder) {
 }
 
 void EBPFTablePSA::emitCacheInstance(CodeBuilder* builder) {
-    if (!tableCacheEnabled)
-        return;
+    if (!tableCacheEnabled) return;
 
     // TODO: make cache size calculation more smart. Consider using annotation or compiler option.
-    size_t cacheSize = std::max((size_t) 1, size / 2);
+    size_t cacheSize = std::max((size_t)1, size / 2);
     builder->target->emitTableDecl(builder, cacheTableName, TableHashLRU,
                                    "struct " + cacheKeyTypeName, "struct " + cacheValueTypeName,
                                    cacheSize);
@@ -987,8 +981,7 @@ void EBPFTablePSA::emitCacheLookup(CodeBuilder* builder, cstring key, cstring va
     builder->appendFormat("%s = &(%s->value)", value.c_str(), cacheVal.c_str());
     builder->endOfStatement(true);
     builder->emitIndent();
-    builder->appendFormat("%s = %s->hit",
-                          program->control->hitVariable.c_str(), cacheVal.c_str());
+    builder->appendFormat("%s = %s->hit", program->control->hitVariable.c_str(), cacheVal.c_str());
     builder->endOfStatement(true);
 
     builder->blockEnd(false);
@@ -1013,19 +1006,18 @@ void EBPFTablePSA::emitCacheUpdate(CodeBuilder* builder, cstring key, cstring va
     builder->appendLine("/* update table cache */");
 
     builder->emitIndent();
-    builder->appendFormat("struct %s %s = {0}",
-                          cacheValueTypeName.c_str(), cacheUpdateVarName.c_str());
+    builder->appendFormat("struct %s %s = {0}", cacheValueTypeName.c_str(),
+                          cacheUpdateVarName.c_str());
     builder->endOfStatement(true);
 
     builder->emitIndent();
-    builder->appendFormat("%s.hit = %s",
-                          cacheUpdateVarName.c_str(), program->control->hitVariable.c_str());
+    builder->appendFormat("%s.hit = %s", cacheUpdateVarName.c_str(),
+                          program->control->hitVariable.c_str());
     builder->endOfStatement(true);
 
     builder->emitIndent();
-    builder->appendFormat(
-            "__builtin_memcpy((void *) &(%s.value), (void *) %s, sizeof(struct %s))",
-            cacheUpdateVarName.c_str(), value.c_str(), valueTypeName.c_str());
+    builder->appendFormat("__builtin_memcpy((void *) &(%s.value), (void *) %s, sizeof(struct %s))",
+                          cacheUpdateVarName.c_str(), value.c_str(), valueTypeName.c_str());
     builder->endOfStatement(true);
 
     builder->emitIndent();

--- a/backends/ebpf/psa/ebpfPsaTable.h
+++ b/backends/ebpf/psa/ebpfPsaTable.h
@@ -35,11 +35,6 @@ class EBPFTablePSA : public EBPFTable {
     const cstring tuplesMapName = instanceName + "_tuples_map";
     const cstring prefixesMapName = instanceName + "_prefixes";
 
-    bool tableCacheEnabled = false;
-    cstring cacheValueTypeName;
-    cstring cacheTableName;
-    void tryEnableTableCache();
-
  protected:
     ActionTranslationVisitor* createActionTranslationVisitor(
         cstring valueName, const EBPFProgram* program) const override;
@@ -47,6 +42,13 @@ class EBPFTablePSA : public EBPFTable {
     void initDirectCounters();
     void initDirectMeters();
     void initImplementation();
+
+    bool tableCacheEnabled = false;
+    cstring cacheValueTypeName;
+    cstring cacheTableName;
+    cstring cacheKeyTypeName;
+    void tryEnableTableCache();
+    void createCacheTypeNames(bool isCacheKeyType, bool isCacheValueType);
 
     void emitTableValue(CodeBuilder* builder, const IR::MethodCallExpression* actionMce,
                         cstring valueName);
@@ -86,7 +88,7 @@ class EBPFTablePSA : public EBPFTable {
     bool dropOnNoMatchingEntryFound() const override;
     static cstring addPrefixFunc(bool trace);
 
-    void emitCacheTypes(CodeBuilder* builder);
+    virtual void emitCacheTypes(CodeBuilder* builder);
     void emitCacheInstance(CodeBuilder* builder);
     void emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) override;
     void emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) override;

--- a/backends/ebpf/psa/ebpfPsaTable.h
+++ b/backends/ebpf/psa/ebpfPsaTable.h
@@ -35,6 +35,11 @@ class EBPFTablePSA : public EBPFTable {
     const cstring tuplesMapName = instanceName + "_tuples_map";
     const cstring prefixesMapName = instanceName + "_prefixes";
 
+    bool tableCacheEnabled = false;
+    cstring cacheValueTypeName;
+    cstring cacheTableName;
+    void tryEnableTableCache();
+
  protected:
     ActionTranslationVisitor* createActionTranslationVisitor(
         cstring valueName, const EBPFProgram* program) const override;
@@ -80,6 +85,12 @@ class EBPFTablePSA : public EBPFTable {
                            cstring actionRunVariable) override;
     bool dropOnNoMatchingEntryFound() const override;
     static cstring addPrefixFunc(bool trace);
+
+    void emitCacheTypes(CodeBuilder* builder);
+    void emitCacheInstance(CodeBuilder* builder);
+    void emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) override;
+    void emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) override;
+    bool cacheEnabled() override { return tableCacheEnabled; }
 
     EBPFCounterPSA* getDirectCounter(cstring name) const {
         auto result = std::find_if(counters.begin(), counters.end(),

--- a/backends/ebpf/psa/externs/ebpfPsaTableImplementation.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaTableImplementation.cpp
@@ -655,8 +655,7 @@ void EBPFActionSelectorPSA::verifyTableEmptyGroupAction(const EBPFTablePSA* inst
 }
 
 void EBPFActionSelectorPSA::emitCacheTypes(CodeBuilder* builder) {
-    if (!tableCacheEnabled)
-        return;
+    if (!tableCacheEnabled) return;
 
     CodeGenInspector commentGen(program->refMap, program->typeMap);
     commentGen.setBuilder(builder);
@@ -693,8 +692,7 @@ void EBPFActionSelectorPSA::emitCacheTypes(CodeBuilder* builder) {
 }
 
 void EBPFActionSelectorPSA::emitCacheVariables(CodeBuilder* builder) {
-    if (!tableCacheEnabled)
-        return;
+    if (!tableCacheEnabled) return;
 
     cacheKeyVar = program->refMap->newName("key_cache");
     cacheDoUpdateVar = program->refMap->newName("do_update_cache");
@@ -709,12 +707,11 @@ void EBPFActionSelectorPSA::emitCacheVariables(CodeBuilder* builder) {
 }
 
 void EBPFActionSelectorPSA::emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) {
-    if (!tableCacheEnabled)
-        return;
+    if (!tableCacheEnabled) return;
 
     builder->emitIndent();
-    builder->appendFormat("%s.group_ref = %s->%s", cacheKeyVar.c_str(),
-                          key.c_str(), referenceName.c_str());
+    builder->appendFormat("%s.group_ref = %s->%s", cacheKeyVar.c_str(), key.c_str(),
+                          referenceName.c_str());
     builder->endOfStatement(true);
 
     unsigned int fieldNumber = 0;
@@ -774,17 +771,15 @@ void EBPFActionSelectorPSA::emitCacheLookup(CodeBuilder* builder, cstring key, c
 }
 
 void EBPFActionSelectorPSA::emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) {
-    if (!tableCacheEnabled)
-        return;
+    if (!tableCacheEnabled) return;
 
     builder->emitIndent();
-    builder->appendFormat("if (%s != NULL && %s != 0) ",
-                          value.c_str(), cacheDoUpdateVar.c_str());
+    builder->appendFormat("if (%s != NULL && %s != 0) ", value.c_str(), cacheDoUpdateVar.c_str());
     builder->blockStart();
 
     builder->emitIndent();
-    builder->appendFormat("BPF_MAP_UPDATE_ELEM(%s, &%s, %s, BPF_ANY);",
-                          cacheTableName.c_str(), key.c_str(), value.c_str());
+    builder->appendFormat("BPF_MAP_UPDATE_ELEM(%s, &%s, %s, BPF_ANY);", cacheTableName.c_str(),
+                          key.c_str(), value.c_str());
     builder->newline();
 
     builder->target->emitTraceMessage(builder, "ActionSelector: cache updated");

--- a/backends/ebpf/psa/externs/ebpfPsaTableImplementation.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaTableImplementation.cpp
@@ -33,6 +33,7 @@ void EBPFTableImplementationPSA::emitTypes(CodeBuilder* builder) {
     if (table == nullptr) return;
     // key is u32, so do not emit type for it
     emitValueType(builder);
+    emitCacheTypes(builder);
 }
 
 void EBPFTableImplementationPSA::emitInitializer(CodeBuilder* builder) { (void)builder; }
@@ -247,6 +248,11 @@ EBPFActionSelectorPSA::EBPFActionSelectorPSA(const EBPFProgram* program, CodeGen
     isGroupEntryName = instanceName + "_is_group_ref";
 
     groupsMapSize = 0;
+
+    if (program->options.enableTableCache) {
+        tableCacheEnabled = true;
+        createCacheTypeNames(true, false);
+    }
 }
 
 void EBPFActionSelectorPSA::emitInitializer(CodeBuilder* builder) {
@@ -308,6 +314,8 @@ void EBPFActionSelectorPSA::emitInstance(CodeBuilder* builder) {
     // action map (ref -> action)
     builder->target->emitTableDecl(builder, actionsMapName, TableHash, "u32",
                                    cstring("struct ") + valueTypeName, size);
+
+    emitCacheInstance(builder);
 }
 
 void EBPFActionSelectorPSA::emitReferenceEntry(CodeBuilder* builder) {
@@ -334,6 +342,8 @@ void EBPFActionSelectorPSA::applyImplementation(CodeBuilder* builder, cstring ta
     cstring checksumValName = "as_checksum_val";
     cstring mapEntryName = "as_map_entry";
 
+    emitCacheVariables(builder);
+
     builder->emitIndent();
     builder->appendFormat("struct %s * %s = NULL", valueTypeName.c_str(), asValueName.c_str());
     builder->endOfStatement(true);
@@ -352,6 +362,8 @@ void EBPFActionSelectorPSA::applyImplementation(CodeBuilder* builder, cstring ta
     builder->blockStart();
     builder->target->emitTraceMessage(builder, "ActionSelector: group reference %u", 1,
                                       effectiveActionRefName.c_str());
+
+    emitCacheLookup(builder, tableValueName, asValueName);
 
     builder->emitIndent();
     builder->append("void * ");
@@ -454,6 +466,10 @@ void EBPFActionSelectorPSA::applyImplementation(CodeBuilder* builder, cstring ta
 
     builder->blockEnd(true);  // is group reference
 
+    if (tableCacheEnabled) {
+        builder->blockEnd(true);
+    }
+
     // 4. Use group state and action ref to get an action data.
 
     builder->emitIndent();
@@ -474,6 +490,8 @@ void EBPFActionSelectorPSA::applyImplementation(CodeBuilder* builder, cstring ta
                                      asValueName);
     builder->endOfStatement(true);
     builder->blockEnd(true);
+
+    emitCacheUpdate(builder, cacheKeyVar, asValueName);
 
     // 5. Execute action.
 
@@ -634,6 +652,144 @@ void EBPFActionSelectorPSA::verifyTableEmptyGroupAction(const EBPFTablePSA* inst
                 "previous table %3% (tables use the same implementation %4%)%5%",
                 rev, lev, table->container->toString(), declaration, additionalNote);
     }
+}
+
+void EBPFActionSelectorPSA::emitCacheTypes(CodeBuilder* builder) {
+    if (!tableCacheEnabled)
+        return;
+
+    CodeGenInspector commentGen(program->refMap, program->typeMap);
+    commentGen.setBuilder(builder);
+
+    // construct cache key type - we need group reference and selector keys
+    builder->emitIndent();
+    builder->appendFormat("struct %s ", cacheKeyTypeName.c_str());
+    builder->blockStart();
+
+    builder->emitIndent();
+    builder->appendFormat("u32 group_ref");
+    builder->endOfStatement(true);
+
+    unsigned int fieldNumber = 0;
+    for (auto s : selectors) {
+        auto type = program->typeMap->getType(s->expression);
+        auto ebpfType = EBPFTypeFactory::instance->create(type);
+        cstring fieldName = Util::printf_format("field%u", fieldNumber++);
+
+        builder->emitIndent();
+        ebpfType->declare(builder, fieldName, false);
+        builder->endOfStatement(false);
+        builder->append(" /* ");
+        s->expression->apply(commentGen);
+        builder->append(" */");
+        builder->newline();
+    }
+
+    builder->blockEnd(false);
+    builder->append(" __attribute__((aligned(4)))");
+    builder->endOfStatement(true);
+
+    // value can be used from Action Selector because there is no need to cache hit variable
+}
+
+void EBPFActionSelectorPSA::emitCacheVariables(CodeBuilder* builder) {
+    if (!tableCacheEnabled)
+        return;
+
+    cacheKeyVar = program->refMap->newName("key_cache");
+    cacheDoUpdateVar = program->refMap->newName("do_update_cache");
+
+    builder->emitIndent();
+    builder->appendFormat("struct %s %s = {0}", cacheKeyTypeName.c_str(), cacheKeyVar.c_str());
+    builder->endOfStatement(true);
+
+    builder->emitIndent();
+    builder->appendFormat("u8 %s = 0", cacheDoUpdateVar.c_str());
+    builder->endOfStatement(true);
+}
+
+void EBPFActionSelectorPSA::emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) {
+    if (!tableCacheEnabled)
+        return;
+
+    builder->emitIndent();
+    builder->appendFormat("%s.group_ref = %s->%s", cacheKeyVar.c_str(),
+                          key.c_str(), referenceName.c_str());
+    builder->endOfStatement(true);
+
+    unsigned int fieldNumber = 0;
+    for (auto s : selectors) {
+        auto type = program->typeMap->getType(s->expression);
+        auto ebpfType = EBPFTypeFactory::instance->create(type);
+        cstring fieldName = Util::printf_format("field%u", fieldNumber++);
+
+        bool memcpy = false;
+        auto scalar = ebpfType->to<EBPFScalarType>();
+        unsigned width = 0;
+        if (scalar != nullptr) {
+            width = scalar->implementationWidthInBits();
+            memcpy = !EBPFScalarType::generatesScalar(width);
+        }
+
+        builder->emitIndent();
+        if (memcpy) {
+            builder->appendFormat("memcpy(&%s.%s, &", cacheKeyVar.c_str(), fieldName.c_str());
+            codeGen->visit(s->expression);
+            builder->appendFormat(", %d)", scalar->bytesRequired());
+        } else {
+            builder->appendFormat("%s.%s = ", cacheKeyVar.c_str(), fieldName.c_str());
+            codeGen->visit(s->expression);
+        }
+        builder->endOfStatement(true);
+    }
+
+    builder->target->emitTraceMessage(builder, "ActionSelector: trying cache...");
+
+    builder->emitIndent();
+    builder->target->emitTableLookup(builder, cacheTableName, cacheKeyVar, value);
+    builder->endOfStatement(true);
+
+    builder->emitIndent();
+    builder->appendFormat("if (%s != NULL) ", value.c_str());
+    builder->blockStart();
+
+    builder->target->emitTraceMessage(builder,
+                                      "ActionSelector: cache hit, skipping later lookup(s)");
+
+    builder->emitIndent();
+    builder->appendFormat("%s = 2", groupStateVarName.c_str());
+    builder->endOfStatement(true);
+
+    builder->blockEnd(false);
+    builder->append(" else ");
+    builder->blockStart();
+
+    builder->target->emitTraceMessage(builder, "ActionSelector: cache miss, nevermind");
+
+    builder->emitIndent();
+    builder->appendFormat("%s = 1", cacheDoUpdateVar.c_str());
+    builder->endOfStatement(true);
+
+    // do normal lookup at this indent level and then end block
+}
+
+void EBPFActionSelectorPSA::emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) {
+    if (!tableCacheEnabled)
+        return;
+
+    builder->emitIndent();
+    builder->appendFormat("if (%s != NULL && %s != 0) ",
+                          value.c_str(), cacheDoUpdateVar.c_str());
+    builder->blockStart();
+
+    builder->emitIndent();
+    builder->appendFormat("BPF_MAP_UPDATE_ELEM(%s, &%s, %s, BPF_ANY);",
+                          cacheTableName.c_str(), key.c_str(), value.c_str());
+    builder->newline();
+
+    builder->target->emitTraceMessage(builder, "ActionSelector: cache updated");
+
+    builder->blockEnd(true);
 }
 
 }  // namespace EBPF

--- a/backends/ebpf/psa/externs/ebpfPsaTableImplementation.h
+++ b/backends/ebpf/psa/externs/ebpfPsaTableImplementation.h
@@ -75,6 +75,11 @@ class EBPFActionSelectorPSA : public EBPFTableImplementationPSA {
 
     void registerTable(const EBPFTablePSA* instance) override;
 
+    void emitCacheTypes(CodeBuilder* builder) override;
+    void emitCacheVariables(CodeBuilder* builder);
+    void emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) override;
+    void emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) override;
+
  protected:
     typedef std::vector<const IR::KeyElement*> SelectorsListType;
 
@@ -88,6 +93,8 @@ class EBPFActionSelectorPSA : public EBPFTableImplementationPSA {
     cstring outputHashMask;
     cstring isGroupEntryName;
     cstring groupStateVarName;
+    cstring cacheKeyVar;
+    cstring cacheDoUpdateVar;
 
     EBPFHashAlgorithmPSA::ArgumentsList unpackSelectors();
     SelectorsListType getSelectorsFromTable(const EBPFTablePSA* instance);

--- a/backends/ebpf/tests/p4testdata/table-cache-lpm.p4
+++ b/backends/ebpf/tests/p4testdata/table-cache-lpm.p4
@@ -1,0 +1,127 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct metadata {
+}
+
+struct headers {
+    ethernet_t       ethernet;
+}
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition accept;
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action a1(EthernetAddress dst) {
+        hdr.ethernet.dstAddr = dst;
+    }
+
+    table tbl_lpm {
+        key = {
+            hdr.ethernet.dstAddr : lpm;
+        }
+        actions = { NoAction; a1; }
+        default_action = NoAction;
+    }
+
+    apply {
+        if (tbl_lpm.apply().hit) {
+            hdr.ethernet.etherType = 0x8601;
+        }
+
+        send_to_port(ostd, (PortId_t) 5);
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {}
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/p4testdata/table-cache-ternary.p4
+++ b/backends/ebpf/tests/p4testdata/table-cache-ternary.p4
@@ -1,0 +1,127 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct metadata {
+}
+
+struct headers {
+    ethernet_t       ethernet;
+}
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition accept;
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action a1(EthernetAddress dst) {
+        hdr.ethernet.dstAddr = dst;
+    }
+
+    table tbl_ternary {
+        key = {
+            hdr.ethernet.dstAddr : ternary;
+        }
+        actions = { NoAction; a1; }
+        default_action = NoAction;
+    }
+
+    apply {
+        if (tbl_ternary.apply().hit) {
+            hdr.ethernet.etherType = 0x8601;
+        }
+
+        send_to_port(ostd, (PortId_t) 5);
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {}
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/ptf/bng.py
+++ b/backends/ebpf/tests/ptf/bng.py
@@ -68,6 +68,7 @@ line_id = 99
 pppoe_session_id = 0xbeac
 core_router_mac = HOST1_MAC
 
+
 def pkt_route(pkt, mac_dst):
     new_pkt = pkt.copy()
     new_pkt[Ether].src = pkt[Ether].dst

--- a/backends/ebpf/tests/ptf/common.py
+++ b/backends/ebpf/tests/ptf/common.py
@@ -96,6 +96,13 @@ class P4EbpfTest(BaseTest):
             self.switch_ns = testutils.test_param_get("namespace")
         self.interfaces = testutils.test_param_get("interfaces").split(",")
 
+        # force rebuild *.o file if compiler option has been hanged for the same P4 file
+        try:
+            os.remove(os.path.join("ptf_out", filename + ".c"))
+            os.remove(self.test_prog_image)
+        except OSError:
+            pass
+
         # fetch data plane ports from network namespace
         global DP_PORTS
         next_idx = 0

--- a/backends/ebpf/tests/ptf/common.py
+++ b/backends/ebpf/tests/ptf/common.py
@@ -57,6 +57,7 @@ PTF_PORTS = [PORT0, PORT1, PORT2]
 # DP_PORTS corresponds to switch interfaces and are used as data plane port numbers inside P4 programs.
 DP_PORTS = dict()
 
+
 def xdp2tc_head_not_supported(cls):
     if cls.xdp2tc_mode(cls) == 'head':
         cls.skip = True
@@ -73,6 +74,7 @@ class P4EbpfTest(BaseTest):
     skip_reason = ''
     switch_ns = 'test'
     p4_file_path = ""
+    p4c_additional_args = ""
 
     def setUp(self):
         super(P4EbpfTest, self).setUp()
@@ -111,6 +113,8 @@ class P4EbpfTest(BaseTest):
 
         if "xdp2tc" in testutils.test_params_get():
             p4args += " --xdp2tc=" + self.xdp2tc_mode()
+
+        p4args = p4args + " " + self.p4_additional_args
 
         logger.info("P4ARGS=" + p4args)
         self.exec_cmd("make -f ../runtime/kernel.mk BPFOBJ={output} P4FILE={p4file} "
@@ -334,7 +338,7 @@ class P4EbpfTest(BaseTest):
         cmd = cmd + self._table_create_str_from_data(data=data, counters=counters, meters=meters)
         self.exec_ns_cmd(cmd, "Table set default entry failed")
 
-    def table_get(self, table, key, indirect=False):
+    def table_get(self, table, key=None, indirect=False):
         """ Returns JSON containing parsed table entry - action data, meters, counters.
             If table has an implementation, set param `indirect` to True.
         """
@@ -342,7 +346,8 @@ class P4EbpfTest(BaseTest):
         if indirect:
             # TODO: cmd = cmd + "ref "
             self.fail("support for indirect table is not implemented yet")
-        cmd = cmd + self._table_create_str_from_key(key=key)
+        if key:
+            cmd = cmd + self._table_create_str_from_key(key=key)
         _, stdout, _ = self.exec_ns_cmd(cmd, "Table get entry failed")
         return json.loads(stdout)[table]
 

--- a/backends/ebpf/tests/ptf/common.py
+++ b/backends/ebpf/tests/ptf/common.py
@@ -96,7 +96,7 @@ class P4EbpfTest(BaseTest):
             self.switch_ns = testutils.test_param_get("namespace")
         self.interfaces = testutils.test_param_get("interfaces").split(",")
 
-        # force rebuild *.o file if compiler option has been hanged for the same P4 file
+        # force rebuild *.o file if compiler option has been changed for the same P4 file
         try:
             os.remove(os.path.join("ptf_out", filename + ".c"))
             os.remove(self.test_prog_image)

--- a/backends/ebpf/tests/ptf/common.py
+++ b/backends/ebpf/tests/ptf/common.py
@@ -114,7 +114,7 @@ class P4EbpfTest(BaseTest):
         if "xdp2tc" in testutils.test_params_get():
             p4args += " --xdp2tc=" + self.xdp2tc_mode()
 
-        p4args = p4args + " " + self.p4_additional_args
+        p4args = p4args + " " + self.p4c_additional_args
 
         logger.info("P4ARGS=" + p4args)
         self.exec_cmd("make -f ../runtime/kernel.mk BPFOBJ={output} P4FILE={p4file} "

--- a/backends/ebpf/tests/ptf/table_implementation.py
+++ b/backends/ebpf/tests/ptf/table_implementation.py
@@ -201,7 +201,16 @@ class SimpleActionSelectorPSATest(ActionSelectorTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet_any_port(self, pkt, output_ports)
 
-        # TODO: test cache
+        if "--table-caching" in self.p4c_additional_args:
+            # modify cache directly and verify its usage
+            self.table_update(table="MyIC_as_cache", key=[1, "22:33:44:55:66:78"], action=1, data=[DP_PORTS[1]])
+            testutils.send_packet(self, PORT0, pkt)
+            testutils.verify_packet(self, pkt, PORT1)
+
+
+class CacheActionSelectorPSATest(SimpleActionSelectorPSATest):
+    """Test ActionSelector in the same way as in the base class but also test cache after it"""
+    p4c_additional_args = "--table-caching"
 
 
 class ActionSelectorTwoTablesSameInstancePSATest(ActionSelectorTest):

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -610,7 +610,6 @@ class PassToKernelStackTest(P4EbpfTest):
 
         super(PassToKernelStackTest, self).tearDown()
 
-
     def runTest(self):
         # simple forward by Linux routing
         pkt = testutils.simple_tcp_packet(eth_dst="00:00:00:00:00:01", ip_src="10.0.0.2", ip_dst="20.0.0.15")
@@ -650,3 +649,57 @@ class PassToKernelStackTest(P4EbpfTest):
         mask.set_do_not_care_scapy(IP, "chksum")
         testutils.verify_packet(self, mask, PORT0)
         self.counter_verify(name="egress_eg_packets", key=[0], packets=0)
+
+
+class LPMTableCachePSATest(P4EbpfTest):
+    p4_file_path = "p4testdata/table-cache-lpm.p4"
+    p4c_additional_args = "--table-caching"
+
+    def runTest(self):
+        # self.table_add(table="ingress_tbl_lpm", key=["00:11:22:33:44:50/44"], action=1, data=["11:22:33:44:55:67"])
+        self.table_add(table="ingress_tbl_lpm", key=["00:11:22:33:44:55/48"], action=1, data=["11:22:33:44:55:66"])
+        # logger.info(self.table_get(table="ingress_tbl_lpm"))
+        pkt = testutils.simple_ip_packet(eth_dst="00:11:22:33:44:50")
+        exp_pkt = testutils.simple_ip_packet(eth_dst="11:22:33:44:55:66")
+        exp_pkt[Ether].type = 0x8601
+
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet(self, exp_pkt, PORT1)
+
+        # modify cache directly - verify that it is used (modify to NoAction)
+        self.table_update(table="ingress_tbl_lpm_cache",
+                          key=["32w0x60", "32w0", "64w0x5044332211000000"], action=0, data=["160w0"])
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet(self, pkt, PORT1)
+
+        # update table - verify clearing cache
+        self.table_update(table="ingress_tbl_lpm", key=["00:11:22:33:44:55"], action=1, data=["11:22:33:44:55:66"])
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet(self, exp_pkt, PORT1)
+
+
+class TernaryTableCachePSATest(P4EbpfTest):
+    p4_file_path = "p4testdata/table-cache-ternary.p4"
+    p4c_additional_args = "--table-caching"
+
+    def runTest(self):
+        self.table_add(table="ingress_tbl_ternary", key=["00:11:22:33:44:55"], action=1, data=["11:22:33:44:55:66"])
+        pkt = testutils.simple_ip_packet(eth_dst="00:11:22:33:44:55")
+        exp_pkt = testutils.simple_ip_packet(eth_dst="11:22:33:44:55:66")
+        exp_pkt[Ether].type = 0x8601
+
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet(self, exp_pkt, PORT1)
+
+        # modify cache directly - verify that it is used (make action default)
+        self.table_update(table="ingress_tbl_ternary_cache",
+                          key=["00:11:22:33:44:55"],
+                          action=1, data=["32w0", "11:22:33:44:55:66", "16w0", "64w0"])
+        testutils.send_packet(self, PORT0, pkt)
+        exp_pkt[Ether].type = 0x0800
+        testutils.verify_packet(self, exp_pkt, PORT1)
+
+        # delete table entry - verify clearing cache
+        self.table_delete(table="ingress_tbl_ternary", key=["00:11:22:33:44:55"])
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet(self, pkt, PORT1)

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -666,13 +666,15 @@ class LPMTableCachePSATest(P4EbpfTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, exp_pkt, PORT1)
 
-        # modify cache directly - verify that it is used (modify to NoAction)
+        # Validate that cache entry is used during packet processing. By altering cache we get two different states
+        # of a table entry with different executed actions. Based on this it is possible to detect which entry is in
+        # use, table entry or cached entry. If we only read cache here then we couldn't test that it is used correctly.
         self.table_update(table="ingress_tbl_lpm_cache",
                           key=["32w0x60", "32w0", "64w0x5044332211000000"], action=0, data=["160w0"])
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)
 
-        # update table - verify clearing cache
+        # Update table entry to test if NIKSS library invalidates cache
         self.table_update(table="ingress_tbl_lpm", key=["00:11:22:33:44:55"], action=1, data=["11:22:33:44:55:66"])
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, exp_pkt, PORT1)
@@ -691,7 +693,9 @@ class TernaryTableCachePSATest(P4EbpfTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, exp_pkt, PORT1)
 
-        # modify cache directly - verify that it is used (make action default)
+        # Validate that cache entry is used during packet processing. By altering cache we get two different states
+        # of a table entry with different executed actions. Based on this it is possible to detect which entry is in
+        # use, table entry or cached entry. If we only read cache here then we couldn't test that it is used correctly.
         self.table_update(table="ingress_tbl_ternary_cache",
                           key=["00:11:22:33:44:55"],
                           action=1, data=["32w0", "11:22:33:44:55:66", "16w0", "64w0"])
@@ -699,7 +703,7 @@ class TernaryTableCachePSATest(P4EbpfTest):
         exp_pkt[Ether].type = 0x0800
         testutils.verify_packet(self, exp_pkt, PORT1)
 
-        # delete table entry - verify clearing cache
+        # Delete table entry to test if NIKSS library invalidates cache
         self.table_delete(table="ingress_tbl_ternary", key=["00:11:22:33:44:55"])
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -656,9 +656,9 @@ class LPMTableCachePSATest(P4EbpfTest):
     p4c_additional_args = "--table-caching"
 
     def runTest(self):
+        # TODO: make this additional entry working
         # self.table_add(table="ingress_tbl_lpm", key=["00:11:22:33:44:50/44"], action=1, data=["11:22:33:44:55:67"])
         self.table_add(table="ingress_tbl_lpm", key=["00:11:22:33:44:55/48"], action=1, data=["11:22:33:44:55:66"])
-        # logger.info(self.table_get(table="ingress_tbl_lpm"))
         pkt = testutils.simple_ip_packet(eth_dst="00:11:22:33:44:50")
         exp_pkt = testutils.simple_ip_packet(eth_dst="11:22:33:44:55:66")
         exp_pkt[Ether].type = 0x8601

--- a/backends/ebpf/tests/ptf/upf.py
+++ b/backends/ebpf/tests/ptf/upf.py
@@ -22,7 +22,7 @@ from scapy.layers.l2 import Ether
 
 GTPU_UDP_PORT=2152
 
-#PTF
+# PTF
 N3_PTF_PORT=0
 N6_PTF_PORT=1
 N9_PTF_PORT=2
@@ -32,7 +32,7 @@ ACCESS = 0
 CORE= 1
 SGi_LAN = 2
 
-#MAC addresses
+# MAC addresses
 UPF_N3_MAC = "00:00:00:00:00:01"
 UPF_N6_MAC = "00:00:00:00:00:02"
 UPF_N9_MAC = "00:00:00:00:00:03"
@@ -61,15 +61,18 @@ SERVER1_IP="192.168.2.21"
 SERVER2_IP="5.5.5.5"
 SERVER2_UDP_PORT=6970
 
+
 def pkt_gtpu_encap(pkt,teid,ip_dst,ip_src):
     return Ether(src=pkt[Ether].src, dst=pkt[Ether].dst) / \
            IP(src=ip_src,dst=ip_dst)/UDP(dport=GTPU_UDP_PORT)/GTP_U_Header(teid=teid)/pkt[Ether].payload
+
 
 def pkt_route(pkt, mac_src, mac_dst):
     new_pkt = pkt.copy()
     new_pkt[Ether].src = mac_src
     new_pkt[Ether].dst = mac_dst
     return new_pkt
+
 
 class UPFTest(P4EbpfTest):
     p4_file_path = "../psa/examples/upf.p4"
@@ -79,10 +82,10 @@ class UPFTest(P4EbpfTest):
         self.table_add(table="ingress_upf_ingress_session_lookup_by_ue_ip", key=[ue_ip], action=1,data=[seid])
 
     def runTest(self):
-        #link number
-        N3_PORT=DP_PORTS[0]
-        N6_PORT=DP_PORTS[1]
-        N9_PORT=DP_PORTS[2]
+        # link number
+        N3_PORT = DP_PORTS[0]
+        N6_PORT = DP_PORTS[1]
+        N9_PORT = DP_PORTS[2]
         self.table_add(table="ingress_upf_ingress_source_interface_lookup_by_port", key=[N3_PORT], action=1, data=[ACCESS])
         self.table_add(table="ingress_upf_ingress_source_interface_lookup_by_port", key=[N9_PORT], action=1, data=[CORE])
         self.table_add(table="ingress_upf_ingress_source_interface_lookup_by_port", key=[N6_PORT], action=1, data=[SGi_LAN])


### PR DESCRIPTION
This PR introduce optimization for the PSA/eBPF backend called `table caching` which adds cache table with only `exact` match keys for time consuming look-ups. We identified three situations where this optimization can improve performance:
- Table with `ternary` (and/or `lpm`, `exact`) key - skip slow TSS algorithm if the key was earlier matched.
- Table with `lpm` (and/or `exact`) key - skip slow `LPM_TRIE` map (especially when there is many entries) if the key was earlier matched.
- `ActionSelector` member selection from group - skip slow checksum calculation for `selector` key if it was earlier calculated.

This optimization may not improve performance in every case, so it must be explicitly enabled by compiler option `--table-caching`.

Limitations/to do:
- `DirectCounter` and `DirectMeter` are not supported by this optimization (tables with these externs will not have enabled cache).
- Cache size is a half of table size, but it would be more configurable or smart during compilation.
- Updates to tables with cache or `ActionSelector` require cache invalidation (`nikss` library will remove all cached entries).