### PR TITLE
[RFC] ebpf/PSA: improve support for wide fields

### DIFF
--- a/backends/ebpf/ebpfDeparser.cpp
+++ b/backends/ebpf/ebpfDeparser.cpp
@@ -212,7 +212,6 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder* builder, cstring field,
         swap = "htonll";
         emitSize = 64;
     }
-    unsigned bytes = ROUNDUP(widthToEmit, 8);
     unsigned shift =
         widthToEmit < 8 ? (emitSize - alignment - widthToEmit) : (emitSize - widthToEmit);
 
@@ -242,19 +241,17 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder* builder, cstring field,
         BUG_CHECK((bitsToWrite > 0) && (bitsToWrite <= 8), "invalid bitsToWrite %d", bitsToWrite);
         builder->emitIndent();
         if (alignment == 0 && bitsToWrite == 8) {  // write whole byte
-            builder->appendFormat(
-                "write_byte(%s, BYTES(%s) + %d, (%s))", program->packetStartVar.c_str(),
-                program->offsetVar.c_str(),
-                widthToEmit > 64 ? bytes - i - 1 : i,  // reversed order for wider fields
-                program->byteVar.c_str());
+            builder->appendFormat("write_byte(%s, BYTES(%s) + %d, (%s))",
+                                  program->packetStartVar.c_str(), program->offsetVar.c_str(),
+                                  i,  // do not reverse byte order
+                                  program->byteVar.c_str());
         } else {  // write partial
             shift = (8 - alignment - bitsToWrite);
-            builder->appendFormat(
-                "write_partial(%s + BYTES(%s) + %d, %d, %d, (%s >> %d))",
-                program->packetStartVar.c_str(), program->offsetVar.c_str(),
-                widthToEmit > 64 ? bytes - i - 1 : i,  // reversed order for wider fields
-                bitsToWrite, shift, program->byteVar.c_str(),
-                widthToEmit > freeBits ? alignment == 0 ? shift : alignment : 0);
+            builder->appendFormat("write_partial(%s + BYTES(%s) + %d, %d, %d, (%s >> %d))",
+                                  program->packetStartVar.c_str(), program->offsetVar.c_str(),
+                                  i,  // do not reverse byte order
+                                  bitsToWrite, shift, program->byteVar.c_str(),
+                                  widthToEmit > freeBits ? alignment == 0 ? shift : alignment : 0);
         }
         builder->endOfStatement(true);
         left -= bitsToWrite;
@@ -264,17 +261,16 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder* builder, cstring field,
         if (bitsInCurrentByte > 0) {
             builder->emitIndent();
             if (bitsToWrite == 8) {
-                builder->appendFormat(
-                    "write_byte(%s, BYTES(%s) + %d + 1, (%s << %d))",
-                    program->packetStartVar.c_str(), program->offsetVar.c_str(),
-                    widthToEmit > 64 ? bytes - i - 1 : i,  // reversed order for wider fields
-                    program->byteVar.c_str(), 8 - alignment % 8);
+                builder->appendFormat("write_byte(%s, BYTES(%s) + %d + 1, (%s << %d))",
+                                      program->packetStartVar.c_str(), program->offsetVar.c_str(),
+                                      i,  // do not reverse byte order
+                                      program->byteVar.c_str(), 8 - alignment % 8);
             } else {
-                builder->appendFormat(
-                    "write_partial(%s + BYTES(%s) + %d + 1, %d, %d, (%s))",
-                    program->packetStartVar.c_str(), program->offsetVar.c_str(),
-                    widthToEmit > 64 ? bytes - i - 1 : i,  // reversed order for wider fields
-                    bitsToWrite, 8 + alignment - bitsToWrite, program->byteVar.c_str());
+                builder->appendFormat("write_partial(%s + BYTES(%s) + %d + 1, %d, %d, (%s))",
+                                      program->packetStartVar.c_str(), program->offsetVar.c_str(),
+                                      i,  // do not reverse byte order
+                                      bitsToWrite, 8 + alignment - bitsToWrite,
+                                      program->byteVar.c_str());
             }
             builder->endOfStatement(true);
             left -= bitsToWrite;

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -72,12 +72,11 @@ class EBPFTable : public EBPFTableBase {
 
     void initKey();
 
- protected:
-    const cstring prefixFieldName = "prefixlen";
-
+ public:
     bool isLPMTable() const;
     bool isTernaryTable() const;
 
+ protected:
     void emitTernaryInstance(CodeBuilder* builder);
 
     virtual void validateKeys() const;
@@ -96,6 +95,7 @@ class EBPFTable : public EBPFTableBase {
     // Use 1024 by default.
     // TODO: make it configurable using compiler options.
     size_t size = 1024;
+    const cstring prefixFieldName = "prefixlen";
 
     EBPFTable(const EBPFProgram* program, const IR::TableBlock* table, CodeGenInspector* codeGen);
     EBPFTable(const EBPFProgram* program, CodeGenInspector* codeGen, cstring name);

--- a/backends/ebpf/psa/ebpfPsaTable.cpp
+++ b/backends/ebpf/psa/ebpfPsaTable.cpp
@@ -137,6 +137,257 @@ class EBPFTablePSAImplementationPropertyVisitor : public EBPFTablePsaPropertyVis
     }
 };
 
+class EBPFTablePSAInitializerUtils {
+ public:
+    // return *real* number of bits required by type
+    static unsigned ebpfTypeWidth(P4::TypeMap* typeMap, const IR::Expression* expr) {
+        auto type = typeMap->getType(expr);
+        auto ebpfType = EBPFTypeFactory::instance->create(type);
+        if (auto scalar = ebpfType->to<EBPFScalarType>()) {
+            unsigned width = scalar->implementationWidthInBits();
+            unsigned alignment = scalar->alignment() * 8;
+            unsigned units = ROUNDUP(width, alignment);
+            return units * alignment;
+        }
+        return 8;  // assume 1 byte if not available such information
+    }
+
+    // Generate hex string and prepend it with zeroes when shorter than required width
+    static cstring genHexStr(const big_int& value, unsigned width, const IR::Expression* expr) {
+        // the required length of hex string, must be an even number
+        unsigned nibbles = 2 * ROUNDUP(width, 8);
+        auto str = value.str(0, std::ios_base::hex);
+        if (str.size() < nibbles) str = std::string(nibbles - str.size(), '0') + str;
+        BUG_CHECK(str.size() == nibbles, "%1%: value size does not match %2% bits", expr, width);
+        return str;
+    }
+};
+
+// Generator for table key/value initializer value (const entries). Can't be used during table
+// lookup because this inspector expects only constant values as initializer.
+class EBPFTablePSAInitializerCodeGen : public CodeGenInspector {
+ protected:
+    unsigned currentKeyEntryIndex = 0;
+    const IR::Entry* currentEntry = nullptr;
+    const EBPFTablePSA* table = nullptr;
+    bool tableHasTernaryMatch = false;
+
+ public:
+    EBPFTablePSAInitializerCodeGen(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
+                                   const EBPFTablePSA* table = nullptr)
+        : CodeGenInspector(refMap, typeMap), table(table) {
+        if (table) tableHasTernaryMatch = table->isTernaryTable();
+    }
+
+    void generateKeyInitializer(const IR::Entry* entry) {
+        currentEntry = entry;
+        // entry->keys is a IR::ListExpression, it lacks information about table key,
+        // we have to visit table->keyGenerator instead.
+        table->keyGenerator->apply(*this);
+    }
+
+    void generateValueInitializer(const IR::Expression* expr) {
+        currentEntry = nullptr;
+        expr->apply(*this);
+    }
+
+    bool preorder(const IR::Constant* expr) override {
+        unsigned width = EBPFTablePSAInitializerUtils::ebpfTypeWidth(typeMap, expr);
+
+        if (EBPFScalarType::generatesScalar(width)) return CodeGenInspector::preorder(expr);
+
+        cstring str = EBPFTablePSAInitializerUtils::genHexStr(expr->value, width, expr);
+        builder->append("{ ");
+        for (size_t i = 0; i < str.size() / 2; ++i)
+            builder->appendFormat("0x%s, ", str.substr(2 * i, 2));
+        builder->append("}");
+
+        return false;
+    }
+
+    bool preorder(const IR::Mask* expr) override {
+        unsigned width = EBPFTablePSAInitializerUtils::ebpfTypeWidth(typeMap, expr->left);
+
+        if (EBPFScalarType::generatesScalar(width)) {
+            visit(expr->left);
+            builder->append(" & ");
+            visit(expr->right);
+        } else {
+            auto lc = expr->left->to<IR::Constant>();
+            auto rc = expr->right->to<IR::Constant>();
+            BUG_CHECK(lc != nullptr, "%1%: expected a constant value", expr->left);
+            BUG_CHECK(rc != nullptr, "%1%: expected a constant value", expr->right);
+            cstring value = EBPFTablePSAInitializerUtils::genHexStr(lc->value, width, expr->left);
+            cstring mask = EBPFTablePSAInitializerUtils::genHexStr(rc->value, width, expr->right);
+            builder->append("{ ");
+            for (size_t i = 0; i < value.size() / 2; ++i)
+                builder->appendFormat("(0x%s & 0x%s), ", value.substr(2 * i, 2),
+                                      mask.substr(2 * i, 2));
+            builder->append("}");
+        }
+
+        return false;
+    }
+
+    // {pre,post}orders for table key initializer
+    bool preorder(const IR::Key*) override {
+        BUG_CHECK(table->keyGenerator->keyElements.size() == currentEntry->keys->size(),
+                  "Entry key size does not match table key size");
+        currentKeyEntryIndex = 0;
+        builder->blockStart();
+        return true;
+    }
+    bool preorder(const IR::KeyElement* key) override {
+        cstring fieldName = ::get(table->keyFieldNames, key);
+        cstring matchType = key->matchType->path->name.name;
+        auto expr = currentEntry->keys->components[currentKeyEntryIndex];
+        unsigned width = EBPFTablePSAInitializerUtils::ebpfTypeWidth(typeMap, key->expression);
+        bool isLPMMatch = matchType == P4::P4CoreLibrary::instance.lpmMatch.name;
+        bool genPrefixLen = !tableHasTernaryMatch && isLPMMatch;
+        bool doSwapBytes = genPrefixLen && EBPFScalarType::generatesScalar(width);
+
+        builder->emitIndent();
+        builder->appendFormat(".%s = ", fieldName.c_str());
+        if (doSwapBytes) {
+            if (width <= 8) {
+                ;  // single byte, nothing to swap
+            } else if (width <= 16) {
+                builder->append("bpf_htons");
+            } else if (width <= 32) {
+                builder->append("bpf_htonl");
+            } else if (width <= 64) {
+                builder->append("bpf_htonll");
+            }
+            builder->append("(");
+        }
+        visit(expr);
+        if (doSwapBytes) builder->append(")");
+        builder->appendLine(",");
+
+        if (genPrefixLen) {
+            unsigned prefixLen = width;
+            if (auto km = expr->to<IR::Mask>()) {
+                auto trailing_zeros = [width](const big_int& n) -> unsigned {
+                    return (n == 0) ? width : boost::multiprecision::lsb(n);
+                };
+                auto count_ones = [](const big_int& n) -> unsigned { return bitcount(n); };
+                auto mask = km->right->to<IR::Constant>()->value;
+                auto len = trailing_zeros(mask);
+                if (len + count_ones(mask) != width) {  // any remaining 0s in the prefix?
+                    ::error(ErrorType::ERR_INVALID, "%1% invalid mask for LPM key", key);
+                    return false;
+                }
+                prefixLen = width - len;
+            }
+
+            builder->emitIndent();
+            builder->appendFormat(".%s = 8*offsetof(struct %s, %s)-32 + %u",
+                                  table->prefixFieldName.c_str(), table->keyTypeName.c_str(),
+                                  fieldName.c_str(), prefixLen);
+            builder->appendLine(",");
+        }
+
+        ++currentKeyEntryIndex;
+        return false;
+    }
+    void postorder(const IR::Key*) override { builder->blockEnd(false); }
+
+    // preorder for value table value initializer
+    bool preorder(const IR::MethodCallExpression* mce) override {
+        auto mi = P4::MethodInstance::resolve(mce, refMap, typeMap);
+        auto ac = mi->to<P4::ActionCall>();
+        BUG_CHECK(ac != nullptr, "%1%: expected an action call", mi);
+        cstring actionName = EBPFObject::externalName(ac->action);
+        cstring fullActionName = table->p4ActionToActionIDName(ac->action);
+
+        builder->blockStart();
+        builder->emitIndent();
+        builder->appendFormat(".action = %s,", fullActionName);
+        builder->newline();
+
+        builder->emitIndent();
+        builder->appendFormat(".u = {.%s = {", actionName.c_str());
+        for (auto p : *mi->substitution.getParametersInArgumentOrder()) {
+            visit(mi->substitution.lookup(p));
+            builder->append(", ");
+        }
+        builder->appendLine("}}");
+
+        builder->blockEnd(false);
+        return false;
+    }
+
+    bool preorder(const IR::PathExpression* p) override { return notSupported(p); }
+};
+
+// Generate mask for whole table key
+class EBPFTablePSATernaryTableMaskGenerator : public Inspector {
+ protected:
+    P4::ReferenceMap* refMap;
+    P4::TypeMap* typeMap;
+    // Mask generation is done using string concatenation,
+    // so use std::string as it behave better in this case than cstring.
+    std::string mask;
+
+ public:
+    EBPFTablePSATernaryTableMaskGenerator(P4::ReferenceMap* refMap, P4::TypeMap* typeMap)
+        : refMap(refMap), typeMap(typeMap) {}
+
+    cstring getMaskStr(const IR::Entry* entry) {
+        mask.clear();
+        entry->keys->apply(*this);
+        return mask;
+    }
+
+    bool preorder(const IR::Constant* expr) override {
+        // exact match, set all bits as 'care'
+        unsigned bytes = ROUNDUP(EBPFTablePSAInitializerUtils::ebpfTypeWidth(typeMap, expr), 8);
+        for (unsigned i = 0; i < bytes; ++i) mask += "ff";
+        return false;
+    }
+    bool preorder(const IR::Mask* expr) override {
+        // Available value and mask, so use only this mask
+        BUG_CHECK(expr->right->is<IR::Constant>(), "%1%: Expected a constant value", expr->right);
+        auto& value = expr->right->to<IR::Constant>()->value;
+        unsigned width = EBPFTablePSAInitializerUtils::ebpfTypeWidth(typeMap, expr->right);
+        mask += EBPFTablePSAInitializerUtils::genHexStr(value, width, expr->right);
+        return false;
+    }
+};
+
+// Build mask initializer for a single table key entry
+class EBPFTablePSATernaryKeyMaskGenerator : public EBPFTablePSAInitializerCodeGen {
+ public:
+    EBPFTablePSATernaryKeyMaskGenerator(P4::ReferenceMap* refMap, P4::TypeMap* typeMap)
+        : EBPFTablePSAInitializerCodeGen(refMap, typeMap, nullptr) {}
+
+    bool preorder(const IR::Constant* expr) override {
+        // MidEnd transforms 0xffff... masks into exact match
+        // So we receive there a Constant same as exact match
+        // So we have to create 0xffff... mask on our own
+        unsigned width = EBPFTablePSAInitializerUtils::ebpfTypeWidth(typeMap, expr);
+        unsigned bytes = ROUNDUP(width, 8);
+
+        if (EBPFScalarType::generatesScalar(width)) {
+            builder->append("0x");
+            for (unsigned i = 0; i < bytes; ++i) builder->append("ff");
+        } else {
+            builder->append("{ ");
+            for (size_t i = 0; i < bytes; ++i) builder->append("0xff, ");
+            builder->append("}");
+        }
+
+        return false;
+    }
+
+    bool preorder(const IR::Mask* expr) override {
+        // Mask value is our value which we want to generate
+        BUG_CHECK(expr->right->is<IR::Constant>(), "%1%: expected constant value", expr->right);
+        EBPFTablePSAInitializerCodeGen::preorder(expr->right->to<IR::Constant>());
+        return false;
+    }
+};
+
 // =====================ActionTranslationVisitorPSA=============================
 ActionTranslationVisitorPSA::ActionTranslationVisitorPSA(const EBPFProgram* program,
                                                          cstring valueName,
@@ -300,10 +551,10 @@ void EBPFTablePSA::emitInstance(CodeBuilder* builder) {
     if (isTernaryTable()) {
         emitTernaryInstance(builder);
         if (hasConstEntries()) {
-            auto entries = getConstEntriesGroupedByPrefix();
-            // A number of tuples is equal to number of unique prefixes
-            int nrOfTuples = entries.size();
-            for (int i = 0; i < nrOfTuples; i++) {
+            auto entries = getConstEntriesGroupedByMask();
+            // A number of tuples is equal to number of unique masks
+            unsigned nrOfTuples = entries.size();
+            for (unsigned i = 0; i < nrOfTuples; i++) {
                 builder->target->emitTableDecl(
                     builder, instanceName + "_tuple_" + std::to_string(i), TableHash,
                     "struct " + keyTypeName, "struct " + valueTypeName, size);
@@ -364,102 +615,38 @@ void EBPFTablePSA::emitInitializer(CodeBuilder* builder) {
 }
 
 void EBPFTablePSA::emitConstEntriesInitializer(CodeBuilder* builder) {
+    const IR::EntriesList* entries = table->container->getEntries();
+    if (entries == nullptr) return;
+
     if (isTernaryTable()) {
         emitTernaryConstEntriesInitializer(builder);
         return;
     }
-    CodeGenInspector cg(program->refMap, program->typeMap);
+
+    EBPFTablePSAInitializerCodeGen cg(program->refMap, program->typeMap, this);
     cg.setBuilder(builder);
-    const IR::EntriesList* entries = table->container->getEntries();
-    if (entries != nullptr) {
-        for (auto entry : entries->entries) {
-            auto keyName = program->refMap->newName("key");
-            auto valueName = program->refMap->newName("value");
-            // construct key
-            builder->emitIndent();
-            builder->appendFormat("struct %s %s = {}", this->keyTypeName.c_str(), keyName.c_str());
-            builder->endOfStatement(true);
-            for (size_t index = 0; index < keyGenerator->keyElements.size(); index++) {
-                auto keyElement = keyGenerator->keyElements[index];
-                cstring fieldName = get(keyFieldNames, keyElement);
-                CHECK_NULL(fieldName);
-                builder->emitIndent();
-                builder->appendFormat("%s.%s = ", keyName.c_str(), fieldName.c_str());
-                auto mtdecl = program->refMap->getDeclaration(keyElement->matchType->path, true);
-                auto matchType = mtdecl->getNode()->to<IR::Declaration_ID>();
-                if (matchType->name.name == P4::P4CoreLibrary::instance.lpmMatch.name) {
-                    auto expr = entry->keys->components[index];
 
-                    auto ebpfType = ::get(keyTypes, keyElement);
-                    unsigned width = 0;
-                    cstring swap;
-                    if (ebpfType->is<EBPFScalarType>()) {
-                        auto scalar = ebpfType->to<EBPFScalarType>();
-                        width = scalar->implementationWidthInBits();
+    for (auto entry : entries->entries) {
+        auto keyName = program->refMap->newName("key");
+        auto valueName = program->refMap->newName("value");
 
-                        if (width <= 8) {
-                            swap = "";  // single byte, nothing to swap
-                        } else if (width <= 16) {
-                            swap = "bpf_htons";
-                        } else if (width <= 32) {
-                            swap = "bpf_htonl";
-                        } else if (width <= 64) {
-                            swap = "bpf_htonll";
-                        } else {
-                            // TODO: handle width > 64 bits
-                            ::error(ErrorType::ERR_UNSUPPORTED,
-                                    "%1%: fields wider than 64 bits are not supported yet",
-                                    fieldName);
-                        }
-                    }
-                    builder->appendFormat("%s(", swap);
-                    if (auto km = expr->to<IR::Mask>()) {
-                        km->left->apply(cg);
-                    } else {
-                        expr->apply(cg);
-                    }
-                    builder->append(")");
-                    builder->endOfStatement(true);
-                    builder->emitIndent();
-                    builder->appendFormat("%s.%s = ", keyName.c_str(), prefixFieldName.c_str());
-                    unsigned prefixLen = 32;
-                    if (auto km = expr->to<IR::Mask>()) {
-                        auto trailing_zeros = [width](const big_int& n) -> int {
-                            return (n == 0) ? width : boost::multiprecision::lsb(n);
-                        };
-                        auto count_ones = [](const big_int& n) -> unsigned { return bitcount(n); };
-                        auto mask = km->right->to<IR::Constant>()->value;
-                        auto len = trailing_zeros(mask);
-                        if (len + count_ones(mask) != width) {  // any remaining 0s in the prefix?
-                            ::error(ErrorType::ERR_INVALID, "%1% invalid mask for LPM key",
-                                    keyElement);
-                            return;
-                        }
-                        prefixLen = width - len;
-                    }
-                    builder->append(prefixLen);
-                    builder->endOfStatement(true);
+        // construct key
+        builder->emitIndent();
+        builder->appendFormat("struct %s %s = ", this->keyTypeName.c_str(), keyName.c_str());
+        cg.generateKeyInitializer(entry);
+        builder->endOfStatement(true);
 
-                } else if (matchType->name.name == P4::P4CoreLibrary::instance.exactMatch.name) {
-                    entry->keys->components[index]->apply(cg);
-                    builder->endOfStatement(true);
-                }
-            }
+        // construct value
+        emitTableValue(builder, entry->action, valueName);
 
-            // construct value
-            auto* mce = entry->action->to<IR::MethodCallExpression>();
-            emitTableValue(builder, mce, valueName.c_str());
+        // emit update
+        auto ret = program->refMap->newName("ret");
+        builder->emitIndent();
+        builder->appendFormat("int %s = ", ret.c_str());
+        builder->target->emitTableUpdate(builder, instanceName, keyName.c_str(), valueName.c_str());
+        builder->newline();
 
-            // emit update
-            auto ret = program->refMap->newName("ret");
-            builder->emitIndent();
-            builder->appendFormat("int %s = ", ret.c_str());
-            builder->target->emitTableUpdate(builder, instanceName, keyName.c_str(),
-                                             valueName.c_str());
-            builder->newline();
-
-            emitMapUpdateTraceMsg(builder, instanceName, ret);
-        }
+        emitMapUpdateTraceMsg(builder, instanceName, ret);
     }
 }
 
@@ -467,12 +654,10 @@ void EBPFTablePSA::emitDefaultActionInitializer(CodeBuilder* builder) {
     const IR::P4Table* t = table->container;
     const IR::Expression* defaultAction = t->getDefaultAction();
     auto actionName = getActionNameExpression(defaultAction);
-    auto mce = defaultAction->to<IR::MethodCallExpression>();
     CHECK_NULL(actionName);
-    CHECK_NULL(mce);
     if (actionName->path->name.originalName != P4::P4CoreLibrary::instance.noAction.name) {
         auto value = program->refMap->newName("value");
-        emitTableValue(builder, mce, value.c_str());
+        emitTableValue(builder, defaultAction, value);
         auto ret = program->refMap->newName("ret");
         builder->emitIndent();
         builder->appendFormat("int %s = ", ret.c_str());
@@ -514,35 +699,14 @@ const IR::PathExpression* EBPFTablePSA::getActionNameExpression(const IR::Expres
     return mce->method->to<IR::PathExpression>();
 }
 
-void EBPFTablePSA::emitTableValue(CodeBuilder* builder, const IR::MethodCallExpression* actionMce,
+void EBPFTablePSA::emitTableValue(CodeBuilder* builder, const IR::Expression* expr,
                                   cstring valueName) {
-    auto mi = P4::MethodInstance::resolve(actionMce, program->refMap, program->typeMap);
-    auto ac = mi->to<P4::ActionCall>();
-    BUG_CHECK(ac != nullptr, "%1%: expected an action call", mi);
-    auto action = ac->action;
-
-    cstring actionName = EBPFObject::externalName(action);
-
-    CodeGenInspector cg(program->refMap, program->typeMap);
+    EBPFTablePSAInitializerCodeGen cg(program->refMap, program->typeMap, this);
     cg.setBuilder(builder);
 
     builder->emitIndent();
     builder->appendFormat("struct %s %s = ", valueTypeName.c_str(), valueName.c_str());
-    builder->blockStart();
-    builder->emitIndent();
-    cstring fullActionName = p4ActionToActionIDName(action);
-    builder->appendFormat(".action = %s,", fullActionName);
-    builder->newline();
-
-    builder->emitIndent();
-    builder->appendFormat(".u = {.%s = {", actionName.c_str());
-    for (auto p : *mi->substitution.getParametersInArgumentOrder()) {
-        auto arg = mi->substitution.lookup(p);
-        arg->apply(cg);
-        builder->append(",");
-    }
-    builder->append("}},\n");
-    builder->blockEnd(false);
+    cg.generateValueInitializer(expr);
     builder->endOfStatement(true);
 }
 
@@ -571,12 +735,9 @@ bool EBPFTablePSA::dropOnNoMatchingEntryFound() const {
 }
 
 void EBPFTablePSA::emitTernaryConstEntriesInitializer(CodeBuilder* builder) {
-    std::vector<std::vector<const IR::Entry*>> entriesGroupedByPrefix =
-        getConstEntriesGroupedByPrefix();
-    if (entriesGroupedByPrefix.empty()) return;
+    auto entriesGroupedByMask = getConstEntriesGroupedByMask();
+    if (entriesGroupedByMask.empty()) return;
 
-    CodeGenInspector cg(program->refMap, program->typeMap);
-    cg.setBuilder(builder);
     std::vector<cstring> keyMasksNames;
     int tuple_id = 0;  // We have preallocated tuple maps with ids starting from 0
 
@@ -587,7 +748,7 @@ void EBPFTablePSA::emitTernaryConstEntriesInitializer(CodeBuilder* builder) {
     builder->endOfStatement(true);
 
     // emit key masks
-    emitKeyMasks(builder, entriesGroupedByPrefix, keyMasksNames);
+    emitKeyMasks(builder, entriesGroupedByMask, keyMasksNames);
 
     builder->newline();
 
@@ -605,8 +766,8 @@ void EBPFTablePSA::emitTernaryConstEntriesInitializer(CodeBuilder* builder) {
     builder->newline();
 
     // emit values + updates
-    for (size_t i = 0; i < entriesGroupedByPrefix.size(); i++) {
-        auto samePrefixEntries = entriesGroupedByPrefix[i];
+    for (size_t i = 0; i < entriesGroupedByMask.size(); i++) {
+        auto sameMaskEntries = entriesGroupedByMask[i];
         valueMask = program->refMap->newName("value_mask");
         std::vector<cstring> keyNames;
         std::vector<cstring> valueNames;
@@ -614,12 +775,14 @@ void EBPFTablePSA::emitTernaryConstEntriesInitializer(CodeBuilder* builder) {
         cstring valuesArray = program->refMap->newName("values");
         cstring keyMaskVarName = keyMasksNames[i];
 
-        if (entriesGroupedByPrefix.size() > i + 1) {
+        if (entriesGroupedByMask.size() > i + 1) {
             nextMask = keyMasksNames[i + 1];
+        } else {
+            nextMask = nullptr;
         }
         emitValueMask(builder, valueMask, nextMask, tuple_id);
         builder->newline();
-        emitKeysAndValues(builder, samePrefixEntries, keyNames, valueNames);
+        emitKeysAndValues(builder, sameMaskEntries, keyNames, valueNames);
 
         // construct keys array
         builder->newline();
@@ -639,7 +802,7 @@ void EBPFTablePSA::emitTernaryConstEntriesInitializer(CodeBuilder* builder) {
         builder->newline();
         builder->emitIndent();
         builder->appendFormat("%s(%s, %s, &%s, &%s, &%s, &%s, %s, %s)", addPrefixFunctionName,
-                              cstring::to_cstring(samePrefixEntries.size()),
+                              cstring::to_cstring(sameMaskEntries.size()),
                               cstring::to_cstring(tuple_id), tuplesMapName, prefixesMapName,
                               keyMaskVarName, valueMask, keysArray, valuesArray);
         builder->endOfStatement(true);
@@ -648,56 +811,40 @@ void EBPFTablePSA::emitTernaryConstEntriesInitializer(CodeBuilder* builder) {
     }
 }
 
-void EBPFTablePSA::emitKeysAndValues(CodeBuilder* builder,
-                                     std::vector<const IR::Entry*>& samePrefixEntries,
+void EBPFTablePSA::emitKeysAndValues(CodeBuilder* builder, EntriesGroup_t& sameMaskEntries,
                                      std::vector<cstring>& keyNames,
                                      std::vector<cstring>& valueNames) {
-    CodeGenInspector cg(program->refMap, program->typeMap);
+    EBPFTablePSAInitializerCodeGen cg(program->refMap, program->typeMap, this);
     cg.setBuilder(builder);
 
-    for (auto entry : samePrefixEntries) {
+    for (auto& entry : sameMaskEntries) {
         cstring keyName = program->refMap->newName("key");
         cstring valueName = program->refMap->newName("value");
         keyNames.push_back(keyName);
         valueNames.push_back(valueName);
         // construct key
         builder->emitIndent();
-        builder->appendFormat("struct %s %s = {}", keyTypeName.c_str(), keyName.c_str());
+        builder->appendFormat("struct %s %s = ", keyTypeName.c_str(), keyName.c_str());
+        cg.generateKeyInitializer(entry.entry);
         builder->endOfStatement(true);
-        for (size_t k = 0; k < keyGenerator->keyElements.size(); k++) {
-            auto keyElement = keyGenerator->keyElements[k];
-            cstring fieldName = get(keyFieldNames, keyElement);
-            CHECK_NULL(fieldName);
-            builder->emitIndent();
-            builder->appendFormat("%s.%s = ", keyName.c_str(), fieldName.c_str());
-            auto expr = entry->keys->components[k];
-            auto ebpfType = get(keyTypes, keyElement);
-            if (auto km = expr->to<IR::Mask>()) {
-                km->left->apply(cg);
-                builder->append(" & ");
-                km->right->apply(cg);
-            } else {
-                expr->apply(cg);
-                builder->append(" & ");
-                emitMaskForExactMatch(builder, fieldName, ebpfType);
-            }
-            builder->endOfStatement(true);
-        }
 
         // construct value
-        auto* mce = entry->action->to<IR::MethodCallExpression>();
-        emitTableValue(builder, mce, valueName.c_str());
+        emitTableValue(builder, entry.entry->action, valueName);
+
+        // setup priority of the entry
+        builder->emitIndent();
+        builder->appendFormat("%s.priority = %u", valueName.c_str(), entry.priority);
+        builder->endOfStatement(true);
     }
 }
 
-void EBPFTablePSA::emitKeyMasks(CodeBuilder* builder,
-                                std::vector<std::vector<const IR::Entry*>>& entriesGrpedByPrefix,
+void EBPFTablePSA::emitKeyMasks(CodeBuilder* builder, EntriesGroupedByMask_t& entriesGroupedByMask,
                                 std::vector<cstring>& keyMasksNames) {
-    CodeGenInspector cg(program->refMap, program->typeMap);
+    EBPFTablePSATernaryKeyMaskGenerator cg(program->refMap, program->typeMap);
     cg.setBuilder(builder);
 
-    for (auto samePrefixEntries : entriesGrpedByPrefix) {
-        auto firstEntry = samePrefixEntries.front();
+    for (auto sameMaskEntries : entriesGroupedByMask) {
+        auto firstEntry = sameMaskEntries.front().entry;
         cstring keyFieldName = program->refMap->newName("key_mask");
         keyMasksNames.push_back(keyFieldName);
 
@@ -718,50 +865,18 @@ void EBPFTablePSA::emitKeyMasks(CodeBuilder* builder,
             builder->emitIndent();
             ebpfType->declare(builder, fieldName, false);
             builder->append(" = ");
-            if (auto mask = expr->to<IR::Mask>()) {
-                mask->right->apply(cg);
-                builder->endOfStatement(true);
-            } else {
-                // MidEnd transforms 0xffff... masks into exact match
-                // So we receive there a Constant same as exact match
-                // So we have to create 0xffff... mask on our own
-                emitMaskForExactMatch(builder, fieldName, ebpfType);
-            }
+            expr->apply(cg);
+            builder->endOfStatement(true);
             builder->emitIndent();
             builder->appendFormat("__builtin_memcpy(%s, &%s, sizeof(%s))", keyFieldNamePtr,
                                   fieldName, fieldName);
             builder->endOfStatement(true);
+            builder->emitIndent();
             builder->appendFormat("%s = %s + sizeof(%s)", keyFieldNamePtr, keyFieldNamePtr,
                                   fieldName);
             builder->endOfStatement(true);
         }
     }
-}
-
-void EBPFTablePSA::emitMaskForExactMatch(CodeBuilder* builder, cstring& fieldName,
-                                         EBPFType* ebpfType) const {
-    unsigned width = 0;
-    if (auto hasWidth = ebpfType->to<IHasWidth>()) {
-        width = hasWidth->widthInBits();
-        if (width <= 8) {
-            width = 8;
-        } else if (width <= 16) {
-            width = 16;
-        } else if (width <= 32) {
-            width = 32;
-        } else if (width <= 64) {
-            width = 64;
-        } else {
-            // TODO: handle width > 64 bits
-            error(ErrorType::ERR_UNSUPPORTED,
-                  "%1%: fields wider than 64 bits are not supported yet", fieldName);
-        }
-    } else {
-        BUG("Cannot assess field bit width");
-    }
-    builder->append("0x");
-    for (size_t j = 0; j < width / 8; j++) builder->append("ff");
-    builder->endOfStatement(true);
 }
 
 void EBPFTablePSA::emitValueMask(CodeBuilder* builder, const cstring valueMask,
@@ -788,55 +903,37 @@ void EBPFTablePSA::emitValueMask(CodeBuilder* builder, const cstring valueMask,
 
 /**
  * This method groups entries with the same prefix into separate lists.
- * For example four entries which have two different prefixes
- * will give as a result a vector of two vectors (each with two entries).
+ * For example four entries which have two different masks
+ * will give as a result a list of two list (each with two entries).
  * @return a vector of vectors with const entries that have the same prefix
  */
-std::vector<std::vector<const IR::Entry*>> EBPFTablePSA::getConstEntriesGroupedByPrefix() {
-    std::vector<std::vector<const IR::Entry*>> entriesGroupedByPrefix;
+EBPFTablePSA::EntriesGroupedByMask_t EBPFTablePSA::getConstEntriesGroupedByMask() {
+    EntriesGroupedByMask_t result;
     const IR::EntriesList* entries = table->container->getEntries();
 
-    if (!entries) return entriesGroupedByPrefix;
+    if (!entries) return result;
 
-    for (int i = 0; i < (int)entries->entries.size(); i++) {
-        auto mainEntr = entries->entries[i];
-        if (!entriesGroupedByPrefix.empty()) {
-            auto last = entriesGroupedByPrefix.back();
-            auto it = std::find(last.begin(), last.end(), mainEntr);
-            if (it != last.end()) {
-                // If this entry was added in a previous iteration
-                continue;
-            }
-        }
-        std::vector<const IR::Entry*> samePrefEntries;
-        samePrefEntries.push_back(mainEntr);
-        for (int j = i; j < (int)entries->entries.size(); j++) {
-            auto refEntr = entries->entries[j];
-            if (i != j) {
-                bool isTheSamePrefix = true;
-                for (size_t k = 0; k < mainEntr->keys->components.size(); k++) {
-                    auto k1 = mainEntr->keys->components[k];
-                    auto k2 = refEntr->keys->components[k];
-                    if (auto k1Mask = k1->to<IR::Mask>()) {
-                        if (auto k2Mask = k2->to<IR::Mask>()) {
-                            auto val1 = k1Mask->right->to<IR::Constant>();
-                            auto val2 = k2Mask->right->to<IR::Constant>();
-                            if (val1->value != val2->value) {
-                                isTheSamePrefix = false;
-                                break;
-                            }
-                        }
-                    }
-                }
-                if (isTheSamePrefix) {
-                    samePrefEntries.push_back(refEntr);
-                }
-            }
-        }
-        entriesGroupedByPrefix.push_back(samePrefEntries);
+    // Group entries by the same mask, container will do deduplication for us. The order of
+    // entries will be changed but this is not a problem because of priority. Ebpf algorithm use
+    // TSS, so every mask have to be tested and there is no strict requirements on masks order.
+    // Priority of entries is equal to P4 program order (first defined has the highest priority).
+    EBPFTablePSATernaryTableMaskGenerator maskGenerator(program->refMap, program->typeMap);
+    std::unordered_map<cstring, std::vector<ConstTernaryEntryDesc>> entriesGroupedByMask;
+    unsigned priority = entries->entries.size() + 1;
+    for (auto entry : entries->entries) {
+        cstring mask = maskGenerator.getMaskStr(entry);
+        ConstTernaryEntryDesc desc = {
+            .entry = entry,
+            .priority = priority--,
+        };
+        entriesGroupedByMask[mask].emplace_back(desc);
     }
 
-    return entriesGroupedByPrefix;
+    // build results
+    for (auto& vec : entriesGroupedByMask) {
+        result.emplace_back(std::move(vec.second));
+    }
+    return result;
 }
 
 bool EBPFTablePSA::hasConstEntries() {

--- a/backends/ebpf/psa/ebpfPsaTable.h
+++ b/backends/ebpf/psa/ebpfPsaTable.h
@@ -28,9 +28,14 @@ class EBPFTableImplementationPSA;
 
 class EBPFTablePSA : public EBPFTable {
  private:
-    std::vector<std::vector<const IR::Entry*>> getConstEntriesGroupedByPrefix();
+    struct ConstTernaryEntryDesc {
+        const IR::Entry* entry;
+        unsigned priority;
+    };
+    typedef std::vector<ConstTernaryEntryDesc> EntriesGroup_t;
+    typedef std::vector<EntriesGroup_t> EntriesGroupedByMask_t;
+    EntriesGroupedByMask_t getConstEntriesGroupedByMask();
     bool hasConstEntries();
-    void emitMaskForExactMatch(CodeBuilder* builder, cstring& fieldName, EBPFType* ebpfType) const;
     const cstring addPrefixFunctionName = "add_prefix_and_entries";
     const cstring tuplesMapName = instanceName + "_tuples_map";
     const cstring prefixesMapName = instanceName + "_prefixes";
@@ -50,18 +55,16 @@ class EBPFTablePSA : public EBPFTable {
     void tryEnableTableCache();
     void createCacheTypeNames(bool isCacheKeyType, bool isCacheValueType);
 
-    void emitTableValue(CodeBuilder* builder, const IR::MethodCallExpression* actionMce,
-                        cstring valueName);
+    void emitTableValue(CodeBuilder* builder, const IR::Expression* expr, cstring valueName);
     void emitDefaultActionInitializer(CodeBuilder* builder);
     void emitConstEntriesInitializer(CodeBuilder* builder);
     void emitTernaryConstEntriesInitializer(CodeBuilder* builder);
     void emitMapUpdateTraceMsg(CodeBuilder* builder, cstring mapName, cstring returnCode) const;
     void emitValueMask(CodeBuilder* builder, cstring valueMask, cstring nextMask,
                        int tupleId) const;
-    void emitKeyMasks(CodeBuilder* builder,
-                      std::vector<std::vector<const IR::Entry*>>& entriesGrpedByPrefix,
+    void emitKeyMasks(CodeBuilder* builder, EntriesGroupedByMask_t& entriesGroupedByMask,
                       std::vector<cstring>& keyMasksNames);
-    void emitKeysAndValues(CodeBuilder* builder, std::vector<const IR::Entry*>& samePrefixEntries,
+    void emitKeysAndValues(CodeBuilder* builder, EntriesGroup_t& sameMaskEntries,
                            std::vector<cstring>& keyNames, std::vector<cstring>& valueNames);
 
     const IR::PathExpression* getActionNameExpression(const IR::Expression* expr) const;

--- a/backends/ebpf/tests/p4testdata/common_headers.p4
+++ b/backends/ebpf/tests/p4testdata/common_headers.p4
@@ -41,6 +41,17 @@ header ipv4_t {
     bit<32> dstAddr;
 }
 
+header ipv6_t {
+    bit<4>   version;
+    bit<8>   trafficClass;
+    bit<20>  flowLabel;
+    bit<16>  payloadLength;
+    bit<8>   nextHeader;
+    bit<8>   hopLimit;
+    bit<128> srcAddr;
+    bit<128> dstAddr;
+}
+
 header mpls_t {
     bit<20> label;
     bit<3>  tc;

--- a/backends/ebpf/tests/p4testdata/wide-field-tables.p4
+++ b/backends/ebpf/tests/p4testdata/wide-field-tables.p4
@@ -1,0 +1,215 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct headers {
+    ethernet_t ethernet;
+    ipv6_t     ipv6;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout empty_t meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x86DD: parse_ipv6;
+            default: accept;
+        }
+    }
+
+    state parse_ipv6 {
+        buffer.extract(parsed_hdr.ipv6);
+        transition accept;
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout empty_t meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x86DD: parse_ipv6;
+            default: accept;
+        }
+    }
+
+    state parse_ipv6 {
+        buffer.extract(parsed_hdr.ipv6);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout empty_t meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action set_dst(bit<128> addr6) {
+        hdr.ipv6.dstAddr = addr6;
+        hdr.ipv6.hopLimit = hdr.ipv6.hopLimit - 1;  // validate number of matches
+    }
+
+    table tbl_default {
+        key = {
+            hdr.ipv6.srcAddr : exact;
+        }
+        actions = { set_dst; NoAction; }
+        default_action = set_dst(128w0xffff_1111_2222_3333_4444_5555_6666_aaaa);
+        size = 100;
+    }
+
+    table tbl_exact {
+        key = {
+            hdr.ipv6.srcAddr : exact;
+        }
+        actions = { set_dst; NoAction; }
+        default_action = NoAction;
+        size = 100;
+    }
+
+    table tbl_lpm {
+        key = {
+            hdr.ipv6.srcAddr : lpm;
+        }
+        actions = { set_dst; NoAction; }
+        default_action = NoAction;
+        size = 100;
+    }
+
+    table tbl_ternary {
+        key = {
+            hdr.ipv6.srcAddr : ternary;
+        }
+        actions = { set_dst; NoAction; }
+        default_action = NoAction;
+        size = 100;
+    }
+
+    table tbl_const_exact {
+        key = {
+            hdr.ipv6.srcAddr : exact;
+        }
+        actions = { set_dst; NoAction; }
+        const entries = {
+            128w0x0003_1111_2222_3333_4444_5555_6666_7777 : set_dst(128w0xffff_1111_2222_3333_4444_5555_6666_0003);
+        }
+    }
+
+    table tbl_const_lpm {
+        key = {
+            hdr.ipv6.srcAddr : lpm;
+        }
+        actions = { set_dst; NoAction; }
+        const entries = {
+            0x0004_1111_2222_3333_4444_5555_6666_0000 &&& 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_0000 : set_dst(128w0xffff_1111_2222_3333_4444_5555_6666_0004);
+        }
+    }
+
+    table tbl_const_ternary {
+        key = {
+            hdr.ipv6.srcAddr : ternary;
+        }
+        actions = { set_dst; NoAction; }
+        const entries = {
+            0x0005_1111_2222_3333_4444_5555_0000_7777 &&& 0xffff_ffff_ffff_ffff_ffff_ffff_0000_ffff : set_dst(128w0xffff_1111_2222_3333_4444_5555_6666_0005);
+            0x0006_1111_2222_3333_4444_5555_6666_7777 &&& 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff : set_dst(128w0xffff_1111_2222_3333_4444_5555_6666_0006);
+        }
+    }
+
+    apply {
+        tbl_default.apply();
+
+        tbl_exact.apply();
+        tbl_lpm.apply();
+        tbl_ternary.apply();
+
+        tbl_const_exact.apply();
+        tbl_const_lpm.apply();
+        tbl_const_ternary.apply();
+
+        send_to_port(ostd, (PortId_t) PORT0);
+    }
+}
+
+control egress(inout headers hdr,
+               inout empty_t meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv6);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in empty_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in empty_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -140,7 +140,7 @@ function install_ptf_ebpf_test_deps() (
     apt-get install -y --no-install-recommends ${LINUX_TOOLS}
   fi
 
-  git clone --depth 1 --recursive --branch v0.2.0 https://github.com/NIKSS-vSwitch/nikss /tmp/nikss
+  git clone --depth 1 --recursive --branch v0.3.0 https://github.com/NIKSS-vSwitch/nikss /tmp/nikss
   cd /tmp/nikss
   ./build_libbpf.sh
   mkdir build


### PR DESCRIPTION
This PR improves support for fields wider than 64 bits. This is done mostly by fixing bugs and some refactors.

The assumption for fields wider than 64 bits is that byte order of them is network byte order, which means that byte order is preserved during parser or deparser.

To achieve initial support for wide fields, the following changes has been made:
- Fixed byte order of bytes emitted in deparser. Parser had proper implementation of this.
- Allow to assign one field to another.
- Improved code for generating table key during lookup. `exact`, `lpm` or `ternary` match type can used.
- Improved generation of table const entries (now mostly using Visitors).
- Improved prefix length calculation for LPM table.

The current PR allows to parse, deparse, match in tables and assign wide fields. Subsequent PR(s) will extend wide fields support for externs.